### PR TITLE
Suggested small fixes for the Unix Shell Loops lesson 

### DIFF
--- a/02-create.md
+++ b/02-create.md
@@ -368,6 +368,19 @@ thesis/quotations.txt
 </div>
 
 <div class="challenge" markdown="1">
+Suppose that you created a `.txt` file in your current directory to contain a list of the 
+statistical tests you will need to do to analyze your data, and named it: `statstics.txt`
+
+After creating and saving this file you realize you misspelled the filename! You want to 
+correct the mistake, which of the following commands could you use to do so?
+
+1. `cp statstics.txt statistics.txt`
+2. `mv statstics.txt statistics.txt`
+3. `mv statstics.txt .`
+4. `cp statstics.txt .`
+</div>
+
+<div class="challenge" markdown="1">
 What is the output of the closing `ls` command in the sequence shown below?
 
 ~~~

--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -447,6 +447,17 @@ wc -l mydata.dat
 </div>
 
 <div class="challenge" markdown="1">
+In our current directory, we want to find the 3 files which have the least number of 
+lines. Which command listed below would work?
+
+1. `wc -l * > sort -n > head -3`
+2. `wc -l * | sort -n | head 1-3`
+3. `wc -l * | head -3 | sort -n`
+4. `wc -l * | sort -n | head -3`
+
+</div>
+
+<div class="challenge" markdown="1">
 The command `uniq` removes adjacent duplicated lines from its input.
 For example, if a file `salmon.txt` contains:
 

--- a/04-loop.md
+++ b/04-loop.md
@@ -456,6 +456,31 @@ done
 </div>
 
 <div class="challenge" markdown="1">
+In another directory, where `ls` returns:
+
+~~~
+fructose.dat    glucose.dat   sucrose.dat   maltose.txt
+~~~
+
+What would be the output of the following loop?
+
+~~~
+for datafile in *.dat
+do
+    cat $datafile >> sugar.dat
+done
+~~~
+
+1.  All of the text from `fructose.dat`, `glucose.dat` and `sucrose.dat` would be 
+    concatenated and saved to a file called `sugar.dat`.
+2.  The text from `sucrose.dat` will be saved to a file called `sugar.dat`.
+3.  All of the text from `fructose.dat`, `glucose.dat`, `sucrose.dat` and `maltose.txt`
+    would be concatenated and saved to a file called `sugar.dat`.
+4.  All of the text from `fructose.dat`, `glucose.dat` and `sucrose.dat` would be printed
+    to the screen and saved to a file called `sugar.dat`
+</div>
+
+<div class="challenge" markdown="1">
 The `expr` does simple arithmetic using command-line parameters:
 
 ~~~

--- a/04-loop.md
+++ b/04-loop.md
@@ -17,9 +17,7 @@ title: Loops
 
 Wildcards and tab completion are two ways to reduce typing (and typing mistakes).
 Another is to tell the shell to do something over and over again.
-Suppose we have several hundred genome data files named `basilisk.dat`, `unicorn.dat`, and so on. In this example, we'll use the `creatures` directory which only has two example files, but the principles can be applied to many many more files at once.
-When new files arrive,
-we'd like to rename the existing ones to `original-basilisk.dat` and `original-unicorn.dat`.
+Suppose we have several hundred genome data files named `basilisk.dat`, `unicorn.dat`, and so on. In this example, we'll use the `creatures` directory which only has two example files, but the principles can be applied to many many more files at once. We would like to modify the files, but also save a version of the original files and rename them as `original-basilisk.dat` and `original-unicorn.dat`.
 We can't use:
 
 ~~~
@@ -424,6 +422,15 @@ What is the output of:
 for datafile in *.dat
 do
     ls *.dat
+done
+~~~
+
+Now, what is the output of:
+
+~~~
+for datafile in *.dat
+do
+	ls $datafile
 done
 ~~~
 </div>

--- a/04-loop.md
+++ b/04-loop.md
@@ -18,6 +18,7 @@ title: Loops
 Wildcards and tab completion are two ways to reduce typing (and typing mistakes).
 Another is to tell the shell to do something over and over again.
 Suppose we have several hundred genome data files named `basilisk.dat`, `unicorn.dat`, and so on. In this example, we'll use the `creatures` directory which only has two example files, but the principles can be applied to many many more files at once. We would like to modify the files, but also save a version of the original files and rename them as `original-basilisk.dat` and `original-unicorn.dat`.
+
 We can't use:
 
 ~~~
@@ -25,15 +26,16 @@ $ mv *.dat original-*.dat
 ~~~
 {:class="in"}
 
-because that would expand (in the two-file case) to:
+because the shell would first attempt to expand the wildcards, and then pass this list of 
+files to mv. This is a problem because when mv receives more than two inputs, it expects 
+the last input to be a directory where it can move all the files it was passed to. Since 
+there is no directory named `original-*.dat` in the `creatures` directory we get an error:
 
 ~~~
-$ mv basilisk.dat unicorn.dat
+usage: mv [-f | -i | -n] [-v] source target
+       mv [-f | -i | -n] [-v] source ... directory
 ~~~
 {:class="in"}
-
-This wouldn't back up our files:
-it would replace the content of `unicorn.dat` with whatever's in `basilisk.dat`.
 
 Instead, we can use a [loop](../../gloss.html#for-loop)
 to do some operation once for each thing in a list.

--- a/05-script.md
+++ b/05-script.md
@@ -391,6 +391,31 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 </div>
 
 <div class="challenge" markdown="1">
+In the molecules directory, you have a shell script called `script.sh` containing the 
+following commands:
+
+~~~
+head $2 $1
+tail $3 $1
+~~~
+
+While you are in the molecules directory, you type the following command:
+
+~~~
+bash script.sh '*.pdb' -1 -1
+~~~
+
+Which of the following outputs would you expect to see?
+
+1. All of the lines between the first and the last lines of each file ending in `*.pdb`
+   in the molecules directory 
+2. The first and the last line of each file ending in `*.pdb` in the molecules directory
+3. The first and the last line of each file in the molecules directory
+4. An error because of the quotes around `*.pdb`
+
+</div>
+
+<div class="challenge" markdown="1">
 Leah has several hundred data files, each of which is formatted like this:
 
 ~~~

--- a/06-find.md
+++ b/06-find.md
@@ -436,6 +436,35 @@ about them."
 </div>
 
 <div class="challenge" markdown="1">
+~~~
+The Tao that is seen
+Is not the true Tao, until
+You bring fresh toner.
+
+With searching comes loss
+and the presence of absence:
+"My Thesis" not found.
+
+Yesterday it worked
+Today it is not working
+Software is like that.
+~~~
+
+From the above text, contained in the file haiku.txt, which command would result in the 
+following output:
+
+~~~
+and the presence of absence
+~~~
+
+1. `grep of haiku.txt`
+2. `grep -E of haiku.txt`
+3. `grep -w of haiku.txt`
+4. `grep -i of haiku.txt`
+
+</div>
+
+<div class="challenge" markdown="1">
 Write a short explanatory comment for the following shell script:
 
 <div class="file" markdown="1">


### PR DESCRIPTION
For my final lesson to become a SWC instructor, I reviewed the unix shell loops lesson and am suggesting two small fixes. The first, is simply to clarify the explanation of the example of why loops are sometimes more useful than wildcards for repeating commands. The second is an addition to the first excercise at the end of the lesson. I think the point of the lesson was to reinforce the difference between using wildcards within for loops versus using $variable_name. Only an example of what happens if you use a wild-card is given. I added an example of using $variable_name so that the learners can clearly examine the differences between these two outputs.