### PR TITLE
04-loop.md: Fill in FIXME challenge titles

### DIFF
--- a/04-loop.md
+++ b/04-loop.md
@@ -393,7 +393,7 @@ so she decides to get some coffee and catch up on her reading.
 > then she can re-run `goostats` on `NENE01729B.txt` simply by typing
 > `!458`.
 
-> ## FIXME {.challenge}
+> ## Loop reading comprehension {.challenge}
 > 
 > Suppose that `ls` initially displays:
 > 
@@ -410,7 +410,7 @@ so she decides to get some coffee and catch up on her reading.
 > done
 > ~~~
 
-> ## FIXME {.challenge}
+> ## Loop reading comprehension with `echo` {.challenge}
 >
 > In the same directory, what is the effect of this loop?
 > 
@@ -430,7 +430,7 @@ so she decides to get some coffee and catch up on her reading.
 >     `xylose.dat`, and copies `sucrose.dat` to create `xylose.dat`.
 > 4.  None of the above.
 
-> ## FIXME {.challenge}
+> ## Nested loop reading comprehension {.challenge}
 >
 > The `expr` does simple arithmetic using command-line parameters:
 > 
@@ -453,7 +453,7 @@ so she decides to get some coffee and catch up on her reading.
 > done
 > ~~~
 
-> ## FIXME {.challenge}
+> ## Leading variable reading comprehension {.challenge}
 > 
 > Describe in words what the following loop does.
 > 


### PR DESCRIPTION
Naming the last challenge is difficult, because it's not really about
loops.  That challenge dates back to 8e77786c (Importing shell lesson
for novices, 2013-11-11), which doesn't explain the pedagogical
motivation for the challenge.  Maybe it's just a trick to keep
students from being to focused on the purported topic when crafting
their answers?  Maybe it's intentionally a throwback to more basic
shell syntax couched in the decoration of the current topic?  Maybe
it's a hint that you can do more with loops than vary arguments to a
single command?  In any event, I'd prefer removing this challenge
entirely, or reworking the content as an example (instead of a
challenge).