### PR TITLE
05-script.md: Fill in FIXME challenge titles

### DIFF
--- a/05-script.md
+++ b/05-script.md
@@ -360,7 +360,7 @@ she could modify her script to check for command-line parameters,
 and use `*[AB].txt` if none were provided.
 Of course, this introduces another tradeoff between flexibility and complexity.
 
-> ## FIXME {.challenge}
+> ## List unique species {.challenge}
 > 
 > Leah has several hundred data files, each of which is formatted like this:
 > 
@@ -380,7 +380,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > `uniq` to print a list of the unique species appearing in each of
 > those files separately.
 
-> ## FIXME {.challenge}
+> ## Find the longest file with a given extension {.challenge}
 > 
 > Write a shell script called `longest.sh` that takes the name of a
 > directory and a filename extension as its parameters, and prints
@@ -394,7 +394,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > would print the name of the `.pdb` file in `/tmp/data` that has
 > the most lines.
 
-> ## FIXME {.challenge}
+> ## Why record commands in the history before running them? {.challenge}
 > 
 > If you run the command:
 > 
@@ -407,7 +407,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > running it. In fact, the shell *always* adds commands to the log
 > before running them. Why do you think it does this?
 
-> ## FIXME {.challenge}
+> ## Script reading comprehension {.challenge}
 > 
 > Joel's `data` directory contains three files: `fructose.dat`,
 > `glucose.dat`, and `sucrose.dat`. Explain what a script called


### PR DESCRIPTION
Naming the history challenge is difficult, because it's not really
about scripts.  That challenge dates back to 8e77786c (Importing shell
lesson for novices, 2013-11-11), which doesn't explain the pedagogical
motivation for the challenge.  We mention using the history command to
populate scripts, but the redo-figure-3.sh example does *not* contain
the trailing history that this challenge points out you'll have.  In
any case, I don't have a clear idea of why the Bash authors would care
about whether commands were appended to the history before or after
the command was executed, so it seems like this will just confuse
students.  Pointing out that that's how the command works is fine, but
that should probably happen when you're showing example uses earlier,
not in a challenge section.

Also, the history command [isn't in POSIX 2013][1].  And of the common
shells I have access to, dash 0.5.7 doesn't have it:

    $ history
    dash: 1: history: not found

I think it's useful enough to mention, but I'd avoid sinking serious
though into this Bash-ism by dropping that challenge and updating the
earlier examples.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html