### PR TITLE
Minor typo fix

### DIFF
--- a/instructors.html
+++ b/instructors.html
@@ -46,7 +46,7 @@
 <li>Setup:
 <ul>
 <li>Run <code>tools/gen-nene.py</code> to regenerate random data files if needed (some are already in the <code>filesystem</code> directory).</li>
-<li>Run `tools/gen-sequence.py' to regenerate random sequence data if needed.</li>
+<li>Run <code>tools/gen-sequence.py</code> to regenerate random sequence data if needed.</li>
 </ul></li>
 <li><p>The <code>filesystem</code> directory contains all the files used in examples.</p></li>
 <li><p>Have learners open a shell and then do <code>whoami</code>, <code>pwd</code>, and <code>ls</code>. Then have them create a directory called <code>workshop</code> and <code>cd</code> into it, so that everything else they do during the lesson is unlikely to harm whatever files they already have.</p></li>

--- a/instructors.md
+++ b/instructors.md
@@ -61,7 +61,7 @@ as long as learners using Windows do not run into roadblocks such as:
 *   Setup:
     *   Run `tools/gen-nene.py` to regenerate random data files if needed
         (some are already in the `filesystem` directory).
-    *   Run `tools/gen-sequence.py' to regenerate random sequence data if needed.
+    *   Run `tools/gen-sequence.py` to regenerate random sequence data if needed.
 
 *   The `filesystem` directory contains all the files used in examples.
 


### PR DESCRIPTION
One of the commands in the instructor's guide was enclosed by a tick and a single quote rather than two ticks, so it was not rendering correctly. This PR fixes the minor issue.