### PR TITLE
Naming the > symbol as right arrow.

### DIFF
--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -106,7 +106,7 @@ Our first step toward a solution is to run the command:
 $ wc -l *.pdb > lengths
 ~~~
 
-The right arrow, `>`, tells the shell to **redirect** the command's output
+The greater than symbol, `>`, tells the shell to **redirect** the command's output
 to a file instead of printing it to the screen.
 The shell will create the file if it doesn't exist,
 or overwrite the contents of that file if it does.

--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -106,7 +106,7 @@ Our first step toward a solution is to run the command:
 $ wc -l *.pdb > lengths
 ~~~
 
-The `>` tells the shell to **redirect** the command's output
+The right arrow, `>`, tells the shell to **redirect** the command's output
 to a file instead of printing it to the screen.
 The shell will create the file if it doesn't exist,
 or overwrite the contents of that file if it does.


### PR DESCRIPTION
It makes it easier to refer to it later on and often students appreciate having names for symbols.