### PR TITLE
[04-loop] Remove 'to' from end of sentence

### DIFF
--- a/04-loop.md
+++ b/04-loop.md
@@ -39,9 +39,9 @@ This wouldn't back up our files, instead we get an error
 mv: target `original-*.dat' is not a directory
 ~~~
 
-This a problem arises when `mv` receives more than two inputs. When this happens, it 
-expects the last input to be a directory where it can move all the files it was passed. 
-Since there is no directory named `original-*.dat` in the `creatures` directory we get an 
+This a problem arises when `mv` receives more than two inputs. When this happens, it
+expects the last input to be a directory where it can move all the files it was passed.
+Since there is no directory named `original-*.dat` in the `creatures` directory we get an
 error.
 
 Instead, we can use a **loop**

--- a/04-loop.md
+++ b/04-loop.md
@@ -40,7 +40,7 @@ mv: target `original-*.dat' is not a directory
 ~~~
 
 This a problem arises when `mv` receives more than two inputs. When this happens, it 
-expects the last input to be a directory where it can move all the files it was passed to. 
+expects the last input to be a directory where it can move all the files it was passed. 
 Since there is no directory named `original-*.dat` in the `creatures` directory we get an 
 error.
 


### PR DESCRIPTION
The sentence reads more clearly without the "to" at the end.