### PR TITLE
Clarified use of . prefix for configuration files

### DIFF
--- a/01-filedir.md
+++ b/01-filedir.md
@@ -345,7 +345,8 @@ it also displays another special directory that's just called `.`,
 which means "the current working directory".
 It may seem redundant to have a name for it,
 but we'll see some uses for it soon.
-Finally, we also see a file called `.bash_profile`. This file usually contains settings to customize the shell (terminal). There may also be similar files called `.bashrc` or `.bash_login`. For this lesson material it does not contain any settings.
+Finally, we also see a file called `.bash_profile`. This file usually contains settings to customize the shell (terminal). For this lesson material it does not contain any settings. There may also be similar files called `.bashrc` or `.bash_login`. The `.` prefix is used to prevent these configuration files from cluttering the terminal when a standard `ls` command is used.
+
 
 
 


### PR DESCRIPTION
I think the use of `.` and `..` as relative pathname symbols is well explain, but it is not clear why `.` is used as a prefix for filenames. This change clarifies the usage of the `.` prefix for configuration files.

(This pull request is part of my instructor training)