### PR TITLE
Suggest deleting What's in a Name?

### DIFF
--- a/01-filedir.md
+++ b/01-filedir.md
@@ -167,26 +167,6 @@ without it,
 the shell thinks we're trying to run a command called `ls-F`,
 which doesn't exist.
 
-> ## What's In A Name? {.callout}
->
-> You may have noticed that all of Nelle's files' names are "something dot
-> something". This is just a convention: we can call a file `mythesis` or
-> almost anything else we want. However, most people use two-part names
-> most of the time to help them (and their programs) tell different kinds
-> of files apart. The second part of such a name is called the
-> **filename extension**, and indicates
-> what type of data the file holds: `.txt` signals a plain text file, `.pdf`
-> indicates a PDF document, `.cfg` is a configuration file full of parameters
-> for some program or other, and so on.
->
-> This is just a convention, albeit an important one. Files contain
-> bytes: it's up to us and our programs to interpret those bytes
-> according to the rules for PDF documents, images, and so on.
->
-> Naming a PNG image of a whale as `whale.mp3` doesn't somehow
-> magically turn it into a recording of whalesong, though it *might*
-> cause the operating system to try to open it with a music player
-> when someone double-clicks it.
 
 Now let's take a look at what's in Nelle's `data` directory by running `ls -F data`,
 i.e.,


### PR DESCRIPTION
I am suggesting we delete this section (What's in a Name?) because I don't find it to be informative. I think most people know what a filename extension is. This lesson is already lengthy (took me more than 15 minutes in total to read through/code in my shell/wrap my head around topics...), so cutting out parts that are not directly relevant to the learning objectives may be worthwhile.