### PR TITLE
Add prev/next/table of contents links to lesson

### DIFF
--- a/02-create.md
+++ b/02-create.md
@@ -398,3 +398,11 @@ but it does find the copy in `thesis` that we didn't delete.
 > The command `ls -t` lists things by time of last change,
 > with most recently changed files or directories first.
 > In what order does `ls -R -t` display things?
+
+---
+
+[Previous Lesson][prev] | [Table of Contents][toc] | [Next Lesson][next]
+
+[prev]: 01-filedir.html
+[toc]: index.html
+[next]: 03-pipefilter.html


### PR DESCRIPTION
## Justification

I think learners ought to have quick ways to jump to the next lesson or back to the table of contents. Currently, I didn’t see any.

## Before/After comparison

![Image showing the current view of the bottom of a lesson, vs. my addition of links to the next lesson, previous lesson, and table of contents](http://f.cl.ly/items/3b0f150Q1z0y1n3T1A44/2015-08-19%20-%20adding%20next-prev%20buttons%20to%20software%20carpentry%20lessons%2008-19-15,%204.32.23%20PM.png)