### PR TITLE
Fix grammatical error: 'and this another example'

### DIFF
--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -77,7 +77,7 @@ $ wc *.pdb
 > However, generally commands like `wc` and `ls` see the lists of
 > file names matching these expressions, but not the wildcards
 > themselves. It is the shell, not the other programs, that deals with
-> expanding wildcards, and this another example of orthogonal design.
+> expanding wildcards, and this is another example of orthogonal design.
 
 If we run `wc -l` instead of just `wc`,
 the output shows only the number of lines per file:


### PR DESCRIPTION
This is just a first pull request to complete the instructor training. Just a little mistake I noticed while reading through the material.