### PR TITLE
Use underscores instead of hyphens in filenames

### DIFF
--- a/01-filedir.md
+++ b/01-filedir.md
@@ -475,7 +475,7 @@ and we will see it in many other tools as we go on.
 > what command will display:
 >
 > ~~~
-> pnas-sub/ pnas-final/ original/
+> pnas_sub/ pnas_final/ original/
 > ~~~
 >
 > 1.  `ls pwd`


### PR DESCRIPTION
Strictly speaking, none of the solutions to the "`ls` reading comprehension" challenge was correct since the requested `ls` output had hyphens instead of underscores in the file names.