### PR TITLE
added navigation "getready" box to index.html

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,6 +37,17 @@ These lessons will start you on a path towards using these resources effectively
 > $ cd && cd Desktop/shell-novice/data
 > ~~~
 
+> ## Navigating this lesson {.getready}
+>
+> This lesson is organized as a series of topics listed below. To return back to this home page, 
+> click "The Unix Shell" link at the top of each topic page. 
+> 
+> On each topic page, there are several different type of boxes that complement the lesson:
+> 
+> 1. Learning objectives for the topic are displayed at top of each page in a Yellow box.
+> 2. Notes and clarifications are interspersed throughout the page in Blue boxes.
+> 3. Challenge questions that extend the material presented in the topic can be found at the bottom of the page in Green boxes.
+
 ## Topics
 
 1.  [Introducing the Shell](00-intro.html)


### PR DESCRIPTION
- topic pages include several different types of colored boxes whose meaning is not immediately obvious to a new learner.
- topic pages are explicitly linked to from index.html, but the reverse links from topic pages to index.html are not immediately obvious to a new learner.
- this pull request adds a "Navigating this lesson" getready box to index.html that alerts the new learner to the meaning of the colored boxes and how to more easily navigate the lesson.