### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 <li>If it’s not unzipped yet, double-click on it to unzip it. You should end up with a new folder called <code>data</code>.</li>
 <li>You can access this folder from the Unix shell with:</li>
 </ol>
-<pre class="input"><code>$ cd &amp;&amp; cd Desktop/shell-novice/data</code></pre>
+<pre class="input"><code>$ cd ; cd Desktop/shell-novice/data</code></pre>
 </div>
 </section>
 <h2 id="topics">Topics</h2>


### PR DESCRIPTION
using the && operator, right at the beginning, might be confusing. I propose that using a semicolon, the standard bash end of line character is better. && does work, and might be "safer" in many cases because it will stop processing the line when a failed command happens, but since cd with no arguments should never fail unless there are serious problems beyond the scope of the exercise, using that functionality is superfluous at this point.