### PR TITLE
revise command from 'pipeline reading' exercise (fixes #280)

### DIFF
--- a/06-find.md
+++ b/06-find.md
@@ -462,7 +462,7 @@ about them."
 > Write a short explanatory comment for the following shell script:
 >
 > ~~~ {.bash}
-> find . -name '*.dat' | wc -l | sort -n
+> wc -l $(find . -name '*.dat') | sort -n
 > ~~~
 
 > ## Matching `ose.dat` but not `temp` {}{.challenge}


### PR DESCRIPTION
The original command always print a single line (the number of .dat files in the current dir and its subdirs), so sort at the end of the pipeline is not necessary. This command finds all *.dat files and prints them in the order of increasing number of lines. For more info see issue #280.