### PR TITLE
Changed typing to pressing

### DIFF
--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -57,7 +57,8 @@ $ wc *.pdb
 > matches filenames that begin with the letter 'p'.
 >
 > `?` is also a wildcard, but it only matches a single character. This
-> means that `p?.pdb` matches `pi.pdb` or `p5.pdb`, but not `propane.pdb`.
+> means that `p?.pdb` matches `pi.pdb` or `p5.pdb` (if we had these files 
+in the molecules directory), but not `propane.pdb`.
 > We can use any number of wildcards at a time: for example, `p*.p?*`
 > matches anything that starts with a 'p' and ends with '.', 'p', and at
 > least one more character (since the '?' has to match one character, and

--- a/04-loop.md
+++ b/04-loop.md
@@ -342,7 +342,7 @@ the shell runs the modified command.
 However, nothing appears to happen --- there is no output.
 After a moment, Nelle realizes that since her script doesn't print anything to the screen any longer,
 she has no idea whether it is running, much less how quickly.
-She kills the job by typing Control-C,
+She kills the job by pressing ^C (^ means Control),
 uses up-arrow to repeat the command,
 and edits it to read:
 

--- a/05-script.md
+++ b/05-script.md
@@ -35,7 +35,7 @@ it selects lines 11-15 of the file `octane.pdb`.
 Remember, we are *not* running it as a command just yet:
 we are putting the commands in a file.
 
-Then we save the file (using CTRL-O), and exit the text editor (using CTRL-X).
+Then we save the file (using ^O), and exit the text editor (using ^X).
 Check that the directory `molecules` now contains a file called `middle.sh`.
 
 Once we have saved the file,


### PR DESCRIPTION
Typing can be misleading, because in order to kill a running job one does not type Control. I changed typing Control-C to pressing ^C (^ means Control)