### PR TITLE
Adds wildcard challenge exercise

### DIFF
--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -81,8 +81,8 @@ $ wc *.pdb
 
 > ## Using wildcards {.challenge}
 >
-> Which `ls` command will produce the output, when run in the
-> `molecules` directory?
+> When run in the `molecules` directory, which `ls` command will
+> produce this output?
 >
 > `ethane.pdb   methane.pdb`
 >

--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -79,6 +79,18 @@ $ wc *.pdb
 > themselves. It is the shell, not the other programs, that deals with
 > expanding wildcards, and this is another example of orthogonal design.
 
+> ## Using wildcards {.challenge}
+>
+> Which `ls` command will produce the output, when run in the
+> `molecules` directory?
+>
+> `ethane.pdb   methane.pdb`
+>
+> 1. `ls *t*ane.pdb`
+> 2. `ls *t?ne.*`
+> 3. `ls *t??ne.pdb`
+> 4. `ls ethane.*`
+
 If we run `wc -l` instead of just `wc`,
 the output shows only the number of lines per file:
 


### PR DESCRIPTION
**Notes on challenge exercise**

This is a multichoice aimed at detecting errors in understanding of wildcards.  The answers are:

* `ls *t*ane.pdb` - also includes octane, pentane; learner misunderstands that * can be zero chars
* `ls *t?ne.*` - returns octane, pentane; learner misunderstands that ? is exactly one char
* `ls *t??ne.pdb` - is correct
* `ls ethane.*` - returns just ethane; learner thinks wildcards are magic

I'd like to think this discussion of the answers would be available to the instructor, but maybe it's easy enough to decode on the spot.

**Notes on positioning and flow**

The start of this lesson is a steeper learning slope than previous lessons.  The learner gets two new concepts -- wildcards and the `wc` command.  I got the sense that adding a wildcard activity might help make wildcards feel more familiar before going on to uses of `wc`.

The cost of having a challenge here is that it disrupts the flow of the example story about inspecting protein data files with `wc`.  I've kept the challenge content focussed on the protein files, but I think once I've gotten a bit more used to making lesson content, I'd like to come back to this section and consider moving the first `wc` usage a paragraph or two later, after all the wildcard content.

