### PR TITLE
fix typo later -> latter

### DIFF
--- a/01-filedir.md
+++ b/01-filedir.md
@@ -438,7 +438,7 @@ Run `pwd` and `ls -F` to ensure that we're in the directory we expect.
 > *the previous directory I was in*, which is faster than having to remember, 
 > then type, the full path.  This is a *very* efficient way of moving back 
 > and forth between directories. The difference between `cd ..` and `cd -` is 
-> that the former brings you *up*, while the later brings you *back*. 
+> that the former brings you *up*, while the latter brings you *back*. 
 
 ### Nelle's Pipeline: Organizing Files
 


### PR DESCRIPTION
Just a typo fix.  I originally intended to expand a smidge on the use of "up" to mean toward-the-root-in-the-directory-tree, and "back" to mean back-in-time-to-the-dir-I-was-in-just-before, but I couldn't find a phrasing clear enough.

Later I'll try and add something about up meaning toward the root, which is so powerful a metaphor it's hard to even think of it as a metaphor -- even though it clashes with the tree/branching metaphor that gives you the word "root".  English is fun isn't it..