### PR TITLE
Adds overlooked backticks around inline code

### DIFF
--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -60,9 +60,9 @@ $ wc *.pdb
 > means that `p?.pdb` matches `pi.pdb` or `p5.pdb`, but not `propane.pdb`.
 > We can use any number of wildcards at a time: for example, `p*.p?*`
 > matches anything that starts with a 'p' and ends with '.', 'p', and at
-> least one more character (since the '?' has to match one character, and
-> the final '\*' can match any number of characters). Thus, `p*.p?*` would
-> match `preferred.practice`, and even `p.pi` (since the first '\*' can
+> least one more character (since the `?` has to match one character, and
+> the final `*` can match any number of characters). Thus, `p*.p?*` would
+> match `preferred.practice`, and even `p.pi` (since the first `*` can
 > match no characters at all), but not `quality.practice` (doesn't start
 > with 'p') or `preferred.p` (there isn't at least one character after the
 > '.p').
@@ -143,7 +143,7 @@ $ cat lengths.txt
 ~~~
 
 Now let's use the `sort` command to sort its contents.
-We will also use the -n flag to specify that the sort is
+We will also use the `-n` flag to specify that the sort is
 numerical instead of alphabetical.
 This does *not* change the file;
 instead, it sends the sorted result to the screen:
@@ -380,7 +380,7 @@ She could just delete them using `rm`,
 but there are actually some analyses she might do later where depth doesn't matter,
 so instead, she'll just be careful later on to select files using the wildcard expression `*[AB].txt`.
 As always,
-the '\*' matches any number of characters;
+the `*` matches any number of characters;
 the expression `[AB]` matches either an 'A' or a 'B',
 so this matches all the valid data files she has.
 

--- a/05-script.md
+++ b/05-script.md
@@ -173,7 +173,7 @@ $ wc -l *.pdb | sort -n
 ~~~
 
 because `wc -l` lists the number of lines in the files
-(recall that wc stands for 'word count', adding the -l flag means 'count lines' instead)
+(recall that `wc` stands for 'word count', adding the `-l` flag means 'count lines' instead)
 and `sort -n` sorts things numerically.
 We could put this in a file,
 but then it would only ever sort a list of `.pdb` files in the current directory.

--- a/06-find.md
+++ b/06-find.md
@@ -220,10 +220,10 @@ matched.  (-F is specified by POSIX.)
 >     Software is like that.
 >
 > We use the `-E` flag and put the pattern in quotes to prevent the shell
-> from trying to interpret it. (If the pattern contained a '\*', for
+> from trying to interpret it. (If the pattern contained a `*`, for
 > example, the shell would try to expand it before running `grep`.) The
-> '\^' in the pattern anchors the match to the start of the line. The '.'
-> matches a single character (just like '?' in the shell), while the 'o'
+> `^` in the pattern anchors the match to the start of the line. The `.`
+> matches a single character (just like `?` in the shell), while the `o`
 > matches an actual 'o'.
 
 While `grep` finds lines in files,


### PR DESCRIPTION
Adds backticks around several instances of direct references to flags, command names, and other chars in command lines.

I've bundled about a dozen changes here -- I think they're all uncontroversial, but I'm happy to discuss.