### PR TITLE
Correct internal link text for renamed chapters.

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,8 +42,8 @@ These lessons will start you on a path towards using these resources effectively
 ## Topics
 
 1.  [Introducing the Shell](00-intro.html)
-2.  [Files and Directories](01-filedir.html)
-3.  [Creating Things](02-create.html)
+2.  [Navigating Files and Directories](01-filedir.html)
+3.  [Working With Files and Directories](02-create.html)
 4.  [Pipes and Filters](03-pipefilter.html)
 5.  [Loops](04-loop.html)
 6.  [Shell Scripts](05-script.html)

--- a/instructors.md
+++ b/instructors.md
@@ -149,7 +149,7 @@ on the front page of the website for more details.
 *   If everything is going well, you can drive home the point that file
     extensions are essentially there to help computers (and human
     readers) understand file content and are not a requirement of files
-    (covered briefly in [Files and Directories](01-filedir.html)).
+    (covered briefly in [Navigating Files and Directories](01-filedir.html)).
     This can be done in the [Pipes and Filters](03-pipefilter.html) section by showing that you
     can redirect standard output to a file without the .txt extension
     (e.g., lengths), and that the resulting file is still a perfectly usable text file.

--- a/reference.md
+++ b/reference.md
@@ -12,7 +12,7 @@ subtitle: Reference
 *   The shell's main disadvantages are its primarily textual nature
     and how cryptic its commands and operation can be.
 
-## [Files and Directories](01-filedir.html)
+## [Navigating Files and Directories](01-filedir.html)
 
 *   The file system is responsible for managing information on the disk.
 *   Information is stored in files, which are stored in directories (folders).
@@ -34,7 +34,7 @@ subtitle: Reference
     but is normally used to indicate the type of data in the file.
 *   Most commands take options (flags) which begin with a '-'.
 
-## [Creating Things](02-create.html)
+## [Working With Files and Directories](02-create.html)
 
 *   `cp old new` copies a file.
 *   `mkdir path` creates a new directory.


### PR DESCRIPTION
URLs don't change (to avoid broken inbound links), but the chapter title
link text needed updating.  Addresses swcarpentry/shell-novice#199 continuing swcarpentry/shell-novice#378