### PR TITLE
Replace /home/amanda by /Users/amanda to be more consistent with the rest of the lesson

### DIFF
--- a/01-filedir.md
+++ b/01-filedir.md
@@ -667,7 +667,7 @@ and we will see it in many other tools as we go on.
 > 
 >1.  `cd .`
 >2.  `cd /`
->3.  `cd /home/amanda`
+>3.  `cd /Users/amanda`
 >4.  `cd ../..`
 >5.  `cd ~`
 >6.  `cd home`


### PR DESCRIPTION
A tiny modification to a challenge of `01-filedir`:
The lesson consistently uses `/Users/...` (OS-X style) instead of `/home/...` (Linux-style). The exercise proposed `cd /home/amanda` as an answer for the question of how to get to Amanda's home directory "which is `/Users/amanda`". I think this makes this more into a "trick question" than it was supposed to be. Also, I think we want to include a correct solution that uses an absolute path.