### PR TITLE
Instructor notes: add solutions to exercises of 01-filedir

### DIFF
--- a/instructors.md
+++ b/instructors.md
@@ -277,10 +277,10 @@ And please also make use of our
 >
 > 1.  `ls pwd`  **no** (`pwd` is not the name of a directory)
 > 2.  `ls -r -F` **yes** (`ls` without directory argument lists files and
-      directories in the current directory)
+>     directories in the current directory)
 > 3.  `ls -r -F /Users/backup`  **yes** (uses the absolute path explicitly)
 > 4.  Either \#2 or \#3 above, but not \#1.  **correct answer** (see
-      explanations above)
+>     explanations above)
 
 > ## Exploring more `ls` arguments {.challenge}
 > 

--- a/instructors.md
+++ b/instructors.md
@@ -229,3 +229,77 @@ And please also make use of our
 [Software Carpentry Windows Installer](http://github.com/swcarpentry/windows-installer).
 
 [shebang]: http://www.in-ulm.de/~mascheck/various/shebang/
+
+## Solutions to exercises
+
+## [Navigating Files and Directories](01-filedir.html)
+
+> ## Many ways to do the same thing - absolute vs relative paths {.challenge}
+>
+> Starting from a filesystem location of `/Users/amanda/data/`, 
+> which of the following commands could Amanda use to navigate to her home directory, 
+> which is `/Users/amanda`?
+> 
+>1.  `cd .` **no** (`.` stands for the current directory)
+>2.  `cd /` **no** (`/` stands for the root directory)
+>3.  `cd /home/amanda` **no** (Amanda's home directory is `/Users/amanda`)
+>4.  `cd ../..` **no** (this goes up two levels, i.e. ends in `/Users`)
+>5.  `cd ~`  **yes** (`~` stands for the user's home directory)
+>6.  `cd home` **no** (this would navigate into a directory `home` in the current directory)
+>7.  `cd ~/data/..` **yes** (complicated, but correct)
+>8.  `cd`  **yes** (shortcut to go back to the user's home directory)
+>9.  `cd ..` **yes** (goes up one level)
+
+> ## Relative path resolution {.challenge}
+>
+> Using the filesystem diagram below, if `pwd` displays `/Users/thing`, 
+what will `ls ../backup` display?
+>
+> 1.  `../backup: No such file or directory`
+> 2.  `2012-12-01 2013-01-08 2013-01-27`
+> 3.  `2012-12-01/ 2013-01-08/ 2013-01-27/`
+> 4.  `original pnas_final pnas_sub`  **<--** because `../backup` refers to `/Users/backup`
+
+> ## `ls` reading comprehension {.challenge}
+>
+> Assuming a directory structure as in the above Figure 
+> (File System for Challenge Questions), if `pwd` displays `/Users/backup`,
+> and `-r` tells `ls` to display things in reverse order,
+> what command will display:
+>
+> ~~~
+> pnas_sub/ pnas_final/ original/
+> ~~~
+>
+> 1.  `ls pwd`  **no** (`pwd` is not the name of a directory)
+> 2.  `ls -r -F` **yes** (`ls` without directory argument lists in the current directory)
+> 3.  `ls -r -F /Users/backup`  **yes** (uses the absolute path explicitly)
+> 4.  Either \#2 or \#3 above, but not \#1.  **correct answer** (see explanations above)
+
+> ## Exploring more `ls` arguments {.challenge}
+> 
+> What does the command `ls` do when used with the `-l` and `-h` arguments?
+> 
+> Some of its output is about properties that we do not cover in this lesson (such
+> as file permissions and ownership), but the rest should be useful
+> nevertheless.
+> 
+> **Answer:**
+> The `-l` arguments makes `ls` use a **l**ong listing format, showing not only
+> the file/directory names but also additional information such as the file size
+> and the time of its last modification. The `-h` argument makes the file size
+> "**h**uman readable", i.e. display something like `5.3K` instead of `5369`.
+
+> ## Listing Recursively and By Time {.challenge}
+> 
+> The command ls -R lists the contents of directories recursively, i.e., lists 
+> their sub-directories, sub-sub-directories, and so on in alphabetical order 
+> at each level. The command ls -t lists things by time of last change, with 
+> most recently changed files or directories first.
+> In what order does ls -R -t display things? Hint: ls -l uses a long listing 
+> format to view timestamps.
+> 
+> **Answer:**
+> The directories are listed alphabetical at each level, the files/directories
+> in each directory are sorted by time of last change.
+

--- a/instructors.md
+++ b/instructors.md
@@ -244,21 +244,25 @@ And please also make use of our
 >2.  `cd /` **no** (`/` stands for the root directory)
 >3.  `cd /home/amanda` **no** (Amanda's home directory is `/Users/amanda`)
 >4.  `cd ../..` **no** (this goes up two levels, i.e. ends in `/Users`)
->5.  `cd ~`  **yes** (`~` stands for the user's home directory)
->6.  `cd home` **no** (this would navigate into a directory `home` in the current directory)
->7.  `cd ~/data/..` **yes** (complicated, but correct)
+>5.  `cd ~`  **yes** (`~` stands for the user's home directory, in this case `/Users/amanda`)
+>6.  `cd home` **no** (this would navigate into a directory `home` in the current directory if it exists)
+>7.  `cd ~/data/..` **yes** (unnecessarily complicated, but correct)
 >8.  `cd`  **yes** (shortcut to go back to the user's home directory)
 >9.  `cd ..` **yes** (goes up one level)
 
 > ## Relative path resolution {.challenge}
 >
-> Using the filesystem diagram below, if `pwd` displays `/Users/thing`, 
-what will `ls ../backup` display?
+> Using the filesystem diagram below, if `pwd` displays `/Users/thing`,
+> what will `ls ../backup` display?
 >
-> 1.  `../backup: No such file or directory`
-> 2.  `2012-12-01 2013-01-08 2013-01-27`
-> 3.  `2012-12-01/ 2013-01-08/ 2013-01-27/`
-> 4.  `original pnas_final pnas_sub`  **<--** because `../backup` refers to `/Users/backup`
+> 1.  `../backup: No such file or directory` **no** (there *is* a directory
+      `backup` in `/Users`) 
+> 2.  `2012-12-01 2013-01-08 2013-01-27` **no** (this is the content of
+      `Users/thing/backup` but with `..` we asked for one level further up)
+> 3.  `2012-12-01/ 2013-01-08/ 2013-01-27/` **no** (see previous explanation,
+      also we did not specify `-F` to display `/` at the end of the directory names)
+> 4.  `original pnas_final pnas_sub`  **yes** (`../backup` refers to
+      `/Users/backup`)
 
 > ## `ls` reading comprehension {.challenge}
 >
@@ -272,9 +276,11 @@ what will `ls ../backup` display?
 > ~~~
 >
 > 1.  `ls pwd`  **no** (`pwd` is not the name of a directory)
-> 2.  `ls -r -F` **yes** (`ls` without directory argument lists in the current directory)
+> 2.  `ls -r -F` **yes** (`ls` without directory argument lists files and
+      directories in the current directory)
 > 3.  `ls -r -F /Users/backup`  **yes** (uses the absolute path explicitly)
-> 4.  Either \#2 or \#3 above, but not \#1.  **correct answer** (see explanations above)
+> 4.  Either \#2 or \#3 above, but not \#1.  **correct answer** (see
+      explanations above)
 
 > ## Exploring more `ls` arguments {.challenge}
 > 


### PR DESCRIPTION
I think it is very useful to have solutions to the SWC exercises, both for learners doing the lessons on their own or revising them after a workshop, as well as for instructors/helpers preparing one. This PR adds solutions for the exercises of the first shell episode to the instructors notes (as in the Python lesson)