### PR TITLE
Minor improvements for `05-script.md`

### DIFF
--- a/05-script.md
+++ b/05-script.md
@@ -174,7 +174,7 @@ $ nano middle.sh
 ~~~
 ~~~ {.output}
 # Select lines from the middle of a file.
-# Usage: middle.sh filename end_line num_lines
+# Usage: bash middle.sh filename end_line num_lines
 head -n "$2" "$1" | tail -n "$3"
 ~~~
 
@@ -211,7 +211,7 @@ $ nano sorted.sh
 ~~~
 ~~~ {.output}
 # Sort filenames by their length.
-# Usage: sorted.sh one_or_more_filenames
+# Usage: bash sorted.sh one_or_more_filenames
 wc -l "$@" | sort -n
 ~~~
 ~~~ {.bash}

--- a/05-script.md
+++ b/05-script.md
@@ -71,8 +71,7 @@ our script's output is exactly what we would get if we ran that pipeline directl
 What if we want to select lines from an arbitrary file?
 We could edit `middle.sh` each time to change the filename,
 but that would probably take longer than just retyping the command.
-Instead,
-let's edit `middle.sh` and replace `octane.pdb` with a special variable called `$1`:
+Instead, let's edit `middle.sh` and make it more versatile:
 
 ~~~ {.bash}
 $ nano middle.sh

--- a/05-script.md
+++ b/05-script.md
@@ -207,9 +207,11 @@ to handle the case of parameters containing spaces
 Here's an example:
 
 ~~~ {.bash}
-$ cat sorted.sh
+$ nano sorted.sh
 ~~~
 ~~~ {.output}
+# Sort filenames by their length.
+# Usage: sorted.sh one_or_more_filenames
 wc -l "$@" | sort -n
 ~~~
 ~~~ {.bash}


### PR DESCRIPTION
A few minor improvements (I hope!) for the "shell script" episode:
* The introduction of command line arguments duplicated an almost identical phrase:

>  Instead, let’s edit middle.sh and replace octane.pdb with a special variable called $1:
> 
> $ nano middle.sh
> 
> Now, within “nano”, replace the text octane.pdb with the special variable called $1:

* The `sorted.sh` script was introduced with `cat sorted.sh`, which is a somewhat advanced convention of introducing a new script -- a learner typing this in will get an error because `sorted.sh` does not exist. Using `nano sorted.sh` seems to be more consistent with the rest of the episode.
* The "Usage" comment for `middle.sh` read: "Usage: middle.sh filename end_line num_lines" but we always call `middle.sh` with `bash` -- I changed it to "Usage: bash middle.sh ..."
  