### PR TITLE
Explanation about two files

### DIFF
--- a/02-create.md
+++ b/02-create.md
@@ -94,18 +94,20 @@ Let's type in a few lines of text.
 Once we're happy with our text, we can press `Ctrl-O` (press the Ctrl or Control key and, while
 holding it down, press the O key) to write our data to disk
 (we'll be asked what file we want to save this to:
-press Return to accept the suggested default of `draft.txt`).
+press Return (Enter) to accept the suggested default of `draft.txt`).
 
 ![Nano in action](fig/nano-screenshot.png)
 
 Once our file is saved, we can use `Ctrl-X` to quit the editor and 
 return to the shell.
 
-> ## Control, ctrl, or ^ key {.callout}
+> ## Control, Ctrl, or ^ key {.callout}
 >
-> The Control key is also called the "Ctrl" key. There are various ways
-> in which using the Control key may be described. For example, you may
-> see an instruction to press the Control key and, while holding it down, 
+> The Control key is also called the "Ctrl" key and the character "^" is
+> a common Unix convention that represents this key. In our lessons however, 
+> we will always refer to it as `Ctrl`. There are various ways
+> in which using the Ctrl key may be described. For example, you may
+> see an instruction to press the Ctrl key and, while holding it down, 
 > press the X key, described as any of:
 >
 > * `Control-X`
@@ -115,7 +117,7 @@ return to the shell.
 > * `^X`
 >
 > In nano, along the bottom of the screen you'll see `^G Get Help ^O WriteOut`.
-> This means that you can use `Control-G` to get help and `Control-O` to save your
+> This means that you can use `Ctrl-G` to get help and `Ctrl-O` to save your
 > file. 
 
 `nano` doesn't leave any output on the screen after it exits,

--- a/03-pipefilter.md
+++ b/03-pipefilter.md
@@ -57,7 +57,8 @@ $ wc *.pdb
 > matches filenames that begin with the letter 'p'.
 >
 > `?` is also a wildcard, but it only matches a single character. This
-> means that `p?.pdb` matches `pi.pdb` or `p5.pdb`, but not `propane.pdb`.
+> means that `p?.pdb` would match `pi.pdb` or `p5.pdb` (if we had these
+files in the molecules directory), but not `propane.pdb`.
 > We can use any number of wildcards at a time: for example, `p*.p?*`
 > matches anything that starts with a 'p' and ends with '.', 'p', and at
 > least one more character (since the `?` has to match one character, and


### PR DESCRIPTION
In the Wild Cards section you refer to two imaginary files pi.pdb and p5.pdb along with propane.pdb as if they are all in the same directory. To avoid confusion, I added a short sentence explaining that we don't have pi.pdb and p5.pdb in the molecules directory but if we had them the ? wild card p?.pdb would find them for us.