### PR TITLE
Flow chart is not entirely representing for loop

### DIFF
--- a/fig/shell_script_for_loop_flow_chart.svg
+++ b/fig/shell_script_for_loop_flow_chart.svg
@@ -557,7 +557,7 @@
 			<text x="27.61" y="360.56" class="st11" v:langID="3081"><v:paragraph v:horizAlign="1"/><v:tabList/>Start</text>		</g>
 		<g id="shape19-77" v:mID="19" v:groupContext="shape" v:layerMember="0" transform="translate(50.3263,-144.84)">
 			<title>Decision</title>
-			<desc>$filename found?</desc>
+			<desc>Next $filename?</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>


### PR DESCRIPTION
I find the flow chart part of the [shell_script_for_loop_flow_chart](https://github.com/swcarpentry/shell-novice/blob/gh-pages/fig/shell_script_for_loop_flow_chart.svg) in 04-loop not really representing a for-loop in that it says `$filename found --> No` --> `End`? If `$filename` is not found, the shell will throw an error.

This PR changes the text to `Next $filename?` in the hope that would work better.

(I don't know how to recreate the `vsd`file)
