### PR TITLE
changed keys for Ctrl commands to \<kbd\>

### DIFF
--- a/02-create.md
+++ b/02-create.md
@@ -136,12 +136,14 @@ return to the shell.
 >
 > * `Control-X`
 > * `Control+X`
+> * `Ctrl+X`
+> * `Ctrl+X`
 > * <kbd>Ctrl</kbd>+<kdb>X</kbd>
 > * <kbd>Ctrl</kbd>+<kdb>X</kbd>
 > * `^X`
 >
 > In nano, along the bottom of the screen you'll see `^G Get Help ^O WriteOut`.
-> This means that you can use `Control-G` to get help and `Control-O` to save your
+> This means that you can use <kbd>Ctrl</kbd>+<kdb>G</kbd> to get help and <kbd>Ctrl</kbd>+<kdb>O</kbd> to save your
 > file. 
 
 `nano` doesn't leave any output on the screen after it exits,

--- a/02-create.md
+++ b/02-create.md
@@ -117,14 +117,14 @@ $ nano draft.txt
 > another directory the first time you "Save As..."
 
 Let's type in a few lines of text.
-Once we're happy with our text, we can press `Ctrl-O` (press the Ctrl or Control key and, while
-holding it down, press the O key) to write our data to disk
+Once we're happy with our text, we can press <kbd>Ctrl</kbd>+<kdb>O</kbd> (press the <kbd>Ctrl</kbd> or Control key and, while
+holding it down, press the <kbd>O</kbd> key) to write our data to disk
 (we'll be asked what file we want to save this to:
 press Return to accept the suggested default of `draft.txt`).
 
 ![Nano in action](fig/nano-screenshot.png)
 
-Once our file is saved, we can use `Ctrl-X` to quit the editor and 
+Once our file is saved, we can use <kbd>Ctrl</kbd>+<kdb>X</kbd> to quit the editor and 
 return to the shell.
 
 > ## Control, ctrl, or ^ key {.callout}
@@ -132,12 +132,12 @@ return to the shell.
 > The Control key is also called the "Ctrl" key. There are various ways
 > in which using the Control key may be described. For example, you may
 > see an instruction to press the Control key and, while holding it down, 
-> press the X key, described as any of:
+> press the <kbd>X</kbd> key, described as any of:
 >
 > * `Control-X`
 > * `Control+X`
-> * `Ctrl-X`
-> * `Ctrl+X`
+> * <kbd>Ctrl</kbd>+<kdb>X</kbd>
+> * <kbd>Ctrl</kbd>+<kdb>X</kbd>
 > * `^X`
 >
 > In nano, along the bottom of the screen you'll see `^G Get Help ^O WriteOut`.

--- a/04-loop.md
+++ b/04-loop.md
@@ -301,7 +301,7 @@ the shell runs the modified command.
 However, nothing appears to happen --- there is no output.
 After a moment, Nelle realizes that since her script doesn't print anything to the screen any longer,
 she has no idea whether it is running, much less how quickly.
-She kills the running command by typing `Ctrl-C`,
+She kills the running command by typing <kbd>Ctrl</kbd>+<kdb>C</kbd>,
 uses up-arrow to repeat the command,
 and edits it to read:
 
@@ -311,8 +311,8 @@ $ for datafile in *[AB].txt; do echo $datafile; bash goostats $datafile stats-$d
 
 > ## Beginning and End {.callout}
 >
-> We can move to the beginning of a line in the shell by typing `Ctrl-A`
-> and to the end using `Ctrl-E`.
+> We can move to the beginning of a line in the shell by typing <kbd>Ctrl</kbd>+<kdb>A</kbd>
+> and to the end using <kbd>Ctrl</kbd>+<kdb>E</kbd>.
 
 When she runs her program now,
 it produces one line of output every five seconds or so:

--- a/05-script.md
+++ b/05-script.md
@@ -35,7 +35,7 @@ it selects lines 11-15 of the file `octane.pdb`.
 Remember, we are *not* running it as a command just yet:
 we are putting the commands in a file.
 
-Then we save the file (using `Ctrl-O`), and exit the text editor (using `Ctrl-X`).
+Then we save the file (using <kbd>Ctrl</kbd>+<kdb>O</kbd>), and exit the text editor (using <kbd>Ctrl</kbd>+<kdb>X</kbd>).
 Check that the directory `molecules` now contains a file called `middle.sh`.
 
 Once we have saved the file,

--- a/discussion.md
+++ b/discussion.md
@@ -21,22 +21,22 @@ speling, but we're stuck with it now.
 
 The shell accepts a few special commands that allow users to interact
 with running processes or programs. You can enter each of these
-"control codes" by holding down the `Ctrl` key and then pressing one
+"control codes" by holding down the <kbd>Ctrl</kbd> key and then pressing one
 of the control characters. In other tutorials, you may see the term
-`Control` or the `^` used to represent the `Ctrl` key (e.g. the
+`Control` or the `^` used to represent the <kbd>Ctrl</kbd> key (e.g. the
 following are all equivalent `Ctrl-C`, `Ctrl+C`, `Control-C`, `Control+C`, `^C`).
 
 | Control Code                 | Description |
 |----------------------------- | ------------|
-| `Ctrl-C` | Interrupts and cancels a running program. This is useful if you want to cancel a command that is taking too long to execute.
-| `Ctrl-D` | Indicates the end of a file or stream of characters that you are entering on the command line. For example, we saw earlier that the `wc` command counts lines, words, and characters in a file. If we just type `wc` and hit the Enter key without providing a file name, then `wc` will assume we want it to analyze all the stuff we type next. After typing our magnum opus directly into the shell prompt, we can then type `Ctrl-D` to tell `wc` that we're done and we'd like to see the results of the word count. |
-| `Ctrl-Z` | Suspends a process but does not terminate it. You can then use the command `fg` to restart the job in the foreground. |
+| <kbd>Ctrl</kbd>+<kdb>C</kbd> | Interrupts and cancels a running program. This is useful if you want to cancel a command that is taking too long to execute.
+| <kbd>Ctrl</kbd>+<kdb>D</kbd> | Indicates the end of a file or stream of characters that you are entering on the command line. For example, we saw earlier that the `wc` command counts lines, words, and characters in a file. If we just type `wc` and hit the Enter key without providing a file name, then `wc` will assume we want it to analyze all the stuff we type next. After typing our magnum opus directly into the shell prompt, we can then type <kbd>Ctrl</kbd>+<kdb>D</kbd> to tell `wc` that we're done and we'd like to see the results of the word count. |
+| <kbd>Ctrl</kbd>+<kdb>Z</kbd> | Suspends a process but does not terminate it. You can then use the command `fg` to restart the job in the foreground. |
 
 For new shell users, these control codes can all appear to have
 the same effect: they make things "go away." But it is helpful to
 understand the differences. In general, if something went wrong and
 you just want to get your shell prompt back, it is better to use
-`Ctrl-C`.
+<kbd>Ctrl</kbd>+<kdb>C</kbd>.
 
 
 ## Other Shells

--- a/reference.md
+++ b/reference.md
@@ -41,7 +41,7 @@ subtitle: Reference
 *   `mv old new` moves (renames) a file or directory.
 *   `rm path` removes (deletes) a file.
 *   `rmdir path` removes (deletes) an empty directory.
-*   Use of the `Ctrl`, or "Control" key may be described in many ways e.g.
+*   Use of the <kbd>Ctrl</kbd>, or "Control" key may be described in many ways e.g.
 *   `Ctrl-X`, `Ctrl+X`, `Control-X`, `Control+X`, `^X`.
 *   The shell does not have a trash bin: once something is deleted, it's really gone.
 *   Nano is a very simple text editor --- please use something else for real work.
@@ -67,7 +67,7 @@ subtitle: Reference
 *   Do not use spaces, quotes, or wildcard characters such as '*' or '?' in filenames, as it complicates variable expansion.
 *   Give files consistent names that are easy to match with wildcard patterns to make it easy to select them for looping.
 *   Use the up-arrow key to scroll up through previous commands to edit and repeat them.
-*   Use `Ctrl-R` to search through the previously entered commands.
+*   Use <kbd>Ctrl</kbd>+<kdb>R</kbd> to search through the previously entered commands.
 *   Use `history` to display recent commands, and `!number` to repeat a command by number.
 
 ## [Shell Scripts](05-script.html)


### PR DESCRIPTION
Render keys as: <kbd>Ctrl</kbd>+<kdb>X</kbd> rather than `Ctrl+X`

`Ctrl` notation kept in discussion of alternate notation for keys