### PR TITLE
Adds missing link to lesson template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Maintainers:
 
 [devenyi_gabriel]: http://software-carpentry.org/team/#devenyi_gabriel
 [srinath_ashwin]: http://software-carpentry.org/team/#srinath_ashwin
+[lesson-example]: https://swcarpentry.github.io/lesson-example/


### PR DESCRIPTION
This tiny commit adds  a missing link to Lesson template –– the text was correct, but the there was no  link for the ID [lesson-example]. 