### PR TITLE
Fix text error, "home" to "current" directory

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -707,7 +707,7 @@ Since the assay machine's output is plain text,
 she will call her files `NENE01729A.txt`, `NENE01812A.txt`, and so on.
 All 1520 files will go into the same directory.
 
-If she is in her home directory,
+Now in her current directory `data-shell`,
 Nelle can see what files she has using the command:
 
 ~~~


### PR DESCRIPTION
The text erroneously said "If she is in her home directory...", however, Nelle actually needs to be in the `data-shell` directory (set as current directory in the previous command) for this to work. 

This is follow up on the error pointed out by @JohnRMoreau in PR #314 discussion.