### PR TITLE
Removed redundant content on script comments

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -102,7 +102,7 @@ has just returned from a six-month survey of the
 [North Pacific Gyre](http://en.wikipedia.org/wiki/North_Pacific_Gyre),
 where she has been sampling gelatinous marine life in the
 [Great Pacific Garbage Patch](http://en.wikipedia.org/wiki/Great_Pacific_Garbage_Patch).
-She has 300 samples in all, and now needs to:
+She has 1520 samples in all, and now needs to:
 
 1.  Run each sample through an assay machine
     that will measure the relative abundance of 300 different proteins.
@@ -124,8 +124,8 @@ Since her lab has eight assay machines that she can use in parallel,
 this step will "only" take about two weeks.
 
 The bad news is that if she has to run `goostat` and `goodiff` by hand,
-she'll have to enter filenames and click "OK" 45,150 times
-(300 runs of `goostat`, plus 300*299/2 (half of 300 times 299) runs of `goodiff`).
+she'll have to enter filenames and click "OK" 46,370 times
+(1520 runs of `goostat`, plus 300*299/2 (half of 300 times 299) runs of `goodiff`).
 At 30 seconds each,
 that will take more than two weeks.
 Not only would she miss her paper deadline,

--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -210,7 +210,10 @@ head -n "$2" "$1" | tail -n "$3"
 
 A comment starts with a `#` character and runs to the end of the line.
 The computer ignores comments,
-but they're invaluable for helping people understand and use scripts.
+but they're invaluable for helping people (including your future self) understand and use scripts.
+The only caveat is that each time you modify the script,
+you should check that the comment is still accurate:
+an explanation that sends the reader in the wrong direction is worse than none at all.
 
 What if we want to process many files in a single pipeline?
 For example, if we want to sort our `.pdb` files by length, we would type:
@@ -290,34 +293,8 @@ $ bash sorted.sh *.pdb ../creatures/*.dat
 > sitting there: the script doesn't appear to do anything.
 {: .callout}
 
-We have two more things to do before we're finished with our simple shell scripts.
-If you look at a script like:
 
-~~~
-$ wc -l "$@" | sort -n
-~~~
-{: .bash}
-
-you can probably puzzle out what it does.
-On the other hand,
-if you look at this script:
-
-~~~
-# List files sorted by number of lines.
-$ wc -l "$@" | sort -n
-~~~
-{: .bash}
-
-you don't have to puzzle it out --- the comment at the top tells you what it does.
-A line or two of documentation like this make it much easier for other people
-(including your future self)
-to re-use your work.
-The only caveat is that each time you modify the script,
-you should check that the comment is still accurate:
-an explanation that sends the reader in the wrong direction is worse than none at all.
-
-Second,
-suppose we have just run a series of commands that did something useful --- for example,
+Suppose we have just run a series of commands that did something useful --- for example,
 that created a graph we'd like to use in a paper.
 We'd like to be able to re-create the graph later if we need to,
 so we want to save the commands in a file.


### PR DESCRIPTION
In the shell scripting lesson there are two different scripts that are created. The importance of commenting your scripts is explained while creating the first one (`middle.sh`) and then re-explained like it had never been explained previously with the second one (`sorted.sh`). What's more, the`sorted.sh` example starts by putting in comments right away and then seems to forget that it did so later on. In this pull request I've tried to address these issues.