### PR TITLE
Added duplicating file structure question to 03-create.md

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -644,4 +644,4 @@ but it does find the copy in `thesis` that we didn't delete.
 > 
 >3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
 >   $ rm -r 2016-6-7-data/
-{.challenge}
+{:.challenge}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -626,32 +626,30 @@ but it does find the copy in `thesis` that we didn't delete.
 > structure from your previous experiment without the data files so you can 
 > add new data. 
 >
-> Use the `north-pacific-gyre` directory under `data-shell` as an example.
-> The goal is to copy the file structure of the `2012-07-03` folder
-> into a folder called `2016-05-20` and remove the data files from 
-> the first folder.
+> Assume that the file structure is in a folder called '2016-05-18-data', 
+> which contains folders named 'raw' and 'processed' that contain data files.
+> The goal is to copy the file structure of the `2016-05-18-data` folder
+> into a folder called `2016-05-20-data` and remove the data files from 
+> the directory you just created.
 > 
-> Navigate to the `north-pacific-gyre` folder. Which of the following set of 
-> commands would achieve this objective? What would the other commands do?
+> Which of the following set of commands would achieve this objective? 
+> What would the other commands do?
 >
-> 1. 
 > ~~~
-> $ cp -r 2016-5-18-data/ 2016-6-7-data/ 
-> $ rm 2016-6-7-data/data/raw/* 
-> $rm 2016-6-7-data/data/processed/*
-> ~~~
-> {: .bash}
-> 2. 
-> ~~~
-> $ rm 2016-6-7-data/data/raw/*
+> $ cp -r 2016-05-18-data/ 2016-05-20-data/ 
+> $ rm 2016-05-20-data/data/raw/* 
 > $ rm 2016-6-7-data/data/processed/*
-> $ cp -r 2016-5-18-data/ 2016-6-7-data/
 > ~~~
 > {: .bash}
-> 3. 
 > ~~~
-> $ cp -r 2016-5-18-data/ 2016-6-7-data/
-> $ rm -r 2016-6-7-data/
+> $ rm 2016-05-20-data/data/raw/*
+> $ rm 2016-05-20-data/data/processed/*
+> $ cp -r 2016-05-18-data/ 2016-5-20-data/
+> ~~~
+> {: .bash}
+> ~~~
+> $ cp -r 2016-05-18-data/ 2016-6-7-data/
+> $ rm -r -i 2016-05-20-data/
 > ~~~
 > {: .bash}
 {: .challenge}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -631,17 +631,18 @@ but it does find the copy in `thesis` that we didn't delete.
 > into a folder called `2016-05-20` and remove the data files from 
 > the first folder.
 > 
-> Navigate to the `file-structure` folder. Which of the following set of 
+> Navigate to the `north-pacific-gyre` folder. Which of the following set of 
 > commands would achieve this objective? What would the other commands do?
 >
 > 1. $ cp -r 2016-5-18-data/ 2016-6-7-data/ 
 >    $ rm 2016-6-7-data/data/raw/* 
 >    $rm 2016-6-7-data/data/processed/*
 >
->2. $ rm 2016-6-7-data/data/raw/*
->   $ rm 2016-6-7-data/data/processed/*
->   $ cp -r 2016-5-18-data/ 2016-6-7-data/
+> 2. $ rm 2016-6-7-data/data/raw/*
+>    $ rm 2016-6-7-data/data/processed/*
+>    $ cp -r 2016-5-18-data/ 2016-6-7-data/
 > 
->3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
->   $ rm -r 2016-6-7-data/
-{:.challenge}
+> 3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
+>    $ rm -r 2016-6-7-data/
+>
+{: .challenge}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -634,15 +634,24 @@ but it does find the copy in `thesis` that we didn't delete.
 > Navigate to the `north-pacific-gyre` folder. Which of the following set of 
 > commands would achieve this objective? What would the other commands do?
 >
-> 1. $ cp -r 2016-5-18-data/ 2016-6-7-data/ 
->    $ rm 2016-6-7-data/data/raw/* 
->    $rm 2016-6-7-data/data/processed/*
->
-> 2. $ rm 2016-6-7-data/data/raw/*
->    $ rm 2016-6-7-data/data/processed/*
->    $ cp -r 2016-5-18-data/ 2016-6-7-data/
-> 
-> 3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
->    $ rm -r 2016-6-7-data/
->
+> 1. 
+> ~~~
+> $ cp -r 2016-5-18-data/ 2016-6-7-data/ 
+> $ rm 2016-6-7-data/data/raw/* 
+> $rm 2016-6-7-data/data/processed/*
+> ~~~
+> {: .bash}
+> 2. 
+> ~~~
+> $ rm 2016-6-7-data/data/raw/*
+> $ rm 2016-6-7-data/data/processed/*
+> $ cp -r 2016-5-18-data/ 2016-6-7-data/
+> ~~~
+> {: .bash}
+> 3. 
+> ~~~
+> $ cp -r 2016-5-18-data/ 2016-6-7-data/
+> $ rm -r 2016-6-7-data/
+> ~~~
+> {: .bash}
 {: .challenge}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -620,7 +620,7 @@ but it does find the copy in `thesis` that we didn't delete.
 >Why would we want this protection when using `rm`?
 {: .challenge}
 
-> ## Copy a folder structure sans files{.challenge}
+> ## Copy a folder structure sans files
 >
 > You're starting a new experiment, and would like to duplicate the file 
 > structure from your previous experiment without the data files so you can 
@@ -644,3 +644,4 @@ but it does find the copy in `thesis` that we didn't delete.
 > 
 >3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
 >   $ rm -r 2016-6-7-data/
+{.challenge}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -619,3 +619,29 @@ but it does find the copy in `thesis` that we didn't delete.
 >What happens when we type `rm -i thesis/quotations.txt`?
 >Why would we want this protection when using `rm`?
 {: .challenge}
+
+> ## Copy a folder structure sans files{.challenge}
+>
+> You're starting a new experiment, and would like to duplicate the file 
+> structure from your previous experiment without the data files so you can 
+> add new data. 
+>
+> Use the `north-pacific-gyre` directory under `data-shell` as an example.
+> The goal is to copy the file structure of the `2012-07-03` folder
+> into a folder called `2016-05-20` and remove the data files from 
+> the first folder.
+> 
+> Navigate to the `file-structure` folder. Which of the following set of 
+> commands would achieve this objective? What would the other commands do?
+>
+> 1. $ cp -r 2016-5-18-data/ 2016-6-7-data/ 
+>    $ rm 2016-6-7-data/data/raw/* 
+>    $rm 2016-6-7-data/data/processed/*
+>
+>2. $ rm 2016-6-7-data/data/raw/*
+>   $ rm 2016-6-7-data/data/processed/*
+>   $ cp -r 2016-5-18-data/ 2016-6-7-data/
+> 
+>3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
+>   $ rm -r 2016-6-7-data/
+{: .challenge}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -644,4 +644,3 @@ but it does find the copy in `thesis` that we didn't delete.
 > 
 >3. $ cp -r 2016-5-18-data/ 2016-6-7-data/
 >   $ rm -r 2016-6-7-data/
-{: .challenge}


### PR DESCRIPTION
When I did closeout for instructor training in May/June, Greg asked me to submit a pull request with the exercise added. 

https://github.com/swcarpentry/shell-novice/pull/413

I didn't get to fixing the things he asked me to do in the comments, and the pages have changed considerably since then. I edited 03-create.md to add the exercise, changing it to be a theoretical exercise, so they don't delete the files they need to work with in a later lesson, and changing the remove tag to rm -r -i to provide an extra sanity check point in the 3rd answer.

Let me know if this addresses your concerns. 