### PR TITLE
Avoid wrong information about selects lines

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -199,7 +199,9 @@ done
 because then the first time through the loop,
 when `$filename` expanded to `basilisk.dat`, the shell would try to run `basilisk.dat` as a program.
 Finally,
-the `head` and `tail` combination selects a set of lines from whatever file is being processed.
+the `head` and `tail` combination selects lines 81-100
+from whatever file is being processed
+(assuming the file has at least 100 lines).
 
 > ## Spaces in Names
 >

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -199,7 +199,7 @@ done
 because then the first time through the loop,
 when `$filename` expanded to `basilisk.dat`, the shell would try to run `basilisk.dat` as a program.
 Finally,
-the `head` and `tail` combination selects lines 81-100 from whatever file is being processed.
+the `head` and `tail` combination selects a set of lines from whatever file is being processed.
 
 > ## Spaces in Names
 >


### PR DESCRIPTION
In http://swcarpentry.github.io/shell-novice/05-loop/ we have

> Finally, the head and tail combination selects lines 81-100 from whatever file is being processed.

This information is not always true because for

    for filenames in * dat
    do
        head -n 100 $filenames | tail -n 20
    done

we will only get the lines 81-100 if the files being processed
have more than 100 lines. If a file has less than 100 lines
we will end with a different set of lines.

This pull request remove the "81-100" to avoid problems.