### PR TITLE
Remove mention of Python

### DIFF
--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -463,9 +463,9 @@ $ grep "FE" $(find .. -name '*.pdb')
 > formulas?
 >
 > The third choice is to recognize that the shell and text processing have
-> their limits, and to use a programming language such as Python instead.
+> their limits, and to use another programming language.
 > When the time comes to do this, don't be too hard on the shell: many
-> modern programming languages, Python included, have borrowed a lot of
+> modern programming languages have borrowed a lot of
 > ideas from it, and imitation is also the sincerest form of praise.
 {: .callout}
 


### PR DESCRIPTION
Because self-learners can be pushed to Python instead of R
or any other programming language because we mention it
on our lesson. Every programming language have their good side.