### PR TITLE
Clarify moving & copying challenge; better segue after mkdir callouts; formatting; whitespace

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -47,7 +47,7 @@ let's open a shell window:
 > `PS1='$ '`
 > into your shell, followed by pressing the 'enter' key,
 > your window should look like our example in this lesson.  
-> This isn't necessary to follow along (in fact, your prompt may have 
+> This isn't necessary to follow along (in fact, your prompt may have
 > other helpful information you want to know about).  This is up to you!  
 {: .callout}
 
@@ -57,8 +57,8 @@ $
 {: .bash}
 
 The dollar sign is a **prompt**, which shows us that the shell is waiting for input;
-your shell may use a different character as a prompt and may add information before 
-the prompt. When typing commands, either from these lessons or from other sources, 
+your shell may use a different character as a prompt and may add information before
+the prompt. When typing commands, either from these lessons or from other sources,
 do not type the prompt, only the commands that follow it.
 
 Type the command `whoami`,
@@ -87,13 +87,13 @@ More specifically, when we type `whoami` the shell:
 
 > ## Username Variation
 >
-> In this lesson, we have used the username `nelle` (associated 
+> In this lesson, we have used the username `nelle` (associated
 > with our hypothetical scientist Nelle) in example input and output throughout.  
-> However, when 
+> However, when
 > you type this lesson's commands on your computer,
-> you should see and use something different, 
-> namely, the username associated with the user account on your computer.  This 
-> username will be the output from `whoami`.  In 
+> you should see and use something different,
+> namely, the username associated with the user account on your computer.  This
+> username will be the output from `whoami`.  In
 > what follows, `nelle` should always be replaced by that username.  
 {: .callout}
 
@@ -124,21 +124,21 @@ $ pwd
 >
 > The home directory path will look different on different operating systems.
 > On Linux it may look like `/home/nelle`,
-> and on Windows it will be similar to `C:\Documents and Settings\nelle` or 
+> and on Windows it will be similar to `C:\Documents and Settings\nelle` or
 > `C:\Users\nelle`.  
 > (Note that it may look slightly different for different versions of Windows.)
-> In future examples, we've used Mac output as the default - Linux and Windows 
+> In future examples, we've used Mac output as the default - Linux and Windows
 > output may differ slightly, but should be generally similar.  
 {: .callout}
 
 To understand what a "home directory" is,
-let's have a look at how the file system as a whole is organized.  For the 
-sake of example, we'll be 
+let's have a look at how the file system as a whole is organized.  For the
+sake of example, we'll be
 illustrating the filesystem on our scientist Nelle's computer.  After this
-illustration, you'll be learning commands to explore your own filesystem, 
+illustration, you'll be learning commands to explore your own filesystem,
 which will be constructed in a similar way, but not be exactly identical.  
 
-On Nelle's computer, the filesystem looks like this: 
+On Nelle's computer, the filesystem looks like this:
 
 ![The File System](../fig/filesystem.svg)
 
@@ -169,19 +169,19 @@ because its name begins with `/`.
 {: .callout}
 
 Underneath `/Users`,
-we find one directory for each user with an account on Nelle's machine, 
+we find one directory for each user with an account on Nelle's machine,
 her colleagues the Mummy and Wolfman.  
 
 ![Home Directories](../fig/home-directories.svg)
 
 The Mummy's files are stored in `/Users/imhotep`,
 Wolfman's in `/Users/larry`,
-and Nelle's in `/Users/nelle`.  Because Nelle is the user in our 
+and Nelle's in `/Users/nelle`.  Because Nelle is the user in our
 examples here, this is why we get `/Users/nelle` as our home directory.  
-Typically, when you open a new command prompt you will be in 
+Typically, when you open a new command prompt you will be in
 your home directory to start.  
 
-Now let's learn the command that will let us see the contents of our 
+Now let's learn the command that will let us see the contents of our
 own filesystem.  We can see what's in our home directory by running `ls`,
 which stands for "listing":
 
@@ -196,10 +196,10 @@ Desktop      Downloads    Movies       Pictures
 ~~~
 {: .output}
 
-(Again, your results may be slightly different depending on your operating 
+(Again, your results may be slightly different depending on your operating
 system and how you have customized your filesystem.)
 
-`ls` prints the names of the files and directories in the current directory in 
+`ls` prints the names of the files and directories in the current directory in
 alphabetical order,
 arranged neatly into columns.
 We can make its output more comprehensible by using the **flag** `-F`,
@@ -358,11 +358,11 @@ and (if you're lucky) provides a few examples of how to use it.
 > support the `man` command. Doing a web search for
 > `unix man page COMMAND` (e.g. `unix man page grep`)
 > provides links to numerous copies of the Unix manual
-> pages online. 
+> pages online.
 > For example, GNU provides links to its
 > [manuals](http://www.gnu.org/manual/manual.html):
 > these include [grep](http://www.gnu.org/software/grep/manual/),
-> and the 
+> and the
 > [core GNU utilities](http://www.gnu.org/software/coreutils/manual/coreutils.html),
 > which covers many commands introduced within this lesson.
 {: .callout}
@@ -392,7 +392,7 @@ which doesn't exist.
 > so we will too.
 {: .callout}
 
-We can also use `ls` to see the contents of a different directory.  Let's take a 
+We can also use `ls` to see the contents of a different directory.  Let's take a
 look at our `Desktop` directory by running `ls -F Desktop`,
 i.e.,
 the command `ls` with the **arguments** `-F` and `Desktop`.
@@ -409,23 +409,23 @@ data-shell/
 ~~~
 {: .output}
 
-Your output should be a list of all the files and sub-directories on your 
-Desktop, including the `data-shell` directory you downloaded at 
-the start of the lesson.  Take a look at your Desktop to confirm that 
+Your output should be a list of all the files and sub-directories on your
+Desktop, including the `data-shell` directory you downloaded at
+the start of the lesson.  Take a look at your Desktop to confirm that
 your output is accurate.  
 
-As you may now see, using a bash shell is strongly dependent on the idea that 
+As you may now see, using a bash shell is strongly dependent on the idea that
 your files are organized in an hierarchical file system.  
 Organizing things hierarchically in this way helps us keep track of our work:
 it's possible to put hundreds of files in our home directory,
 just as it's possible to pile hundreds of printed papers on our desk,
 but it's a self-defeating strategy.
 
-Now that we know the `data-shell` directory is located on our Desktop, we 
+Now that we know the `data-shell` directory is located on our Desktop, we
 can do two things.  
 
-First, we can look at its contents, using the same strategy as before, passing 
-a directory name to `ls`: 
+First, we can look at its contents, using the same strategy as before, passing
+a directory name to `ls`:
 
 ~~~
 $ ls -F Desktop/data-shell
@@ -438,19 +438,19 @@ data/               north-pacific-gyre/ pizza.cfg           writing/
 ~~~
 {: .output}
 
-Second, we can actually change our location to a different directory, so 
+Second, we can actually change our location to a different directory, so
 we are no longer located in
 our home directory.  
 
-The command to change locations is `cd` followed by a 
+The command to change locations is `cd` followed by a
 directory name to change our working directory.
 `cd` stands for "change directory",
 which is a bit misleading:
 the command doesn't change the directory,
 it changes the shell's idea of what directory we are in.
 
-Let's say we want to move to the `data` directory we saw above.  We can 
-use the following series of commands to get there: 
+Let's say we want to move to the `data` directory we saw above.  We can
+use the following series of commands to get there:
 
 ~~~
 $ cd Desktop
@@ -459,9 +459,9 @@ $ cd data
 ~~~
 {: .bash}
 
-These commands will move us from our home directory onto our Desktop, then into 
+These commands will move us from our home directory onto our Desktop, then into
 the `data-shell` directory, then into the `data` directory.  `cd` doesn't print anything,
-but if we run `pwd` after it, we can see that we are now 
+but if we run `pwd` after it, we can see that we are now
 in `/Users/nelle/Desktop/data-shell/data`.
 If we run `ls` without arguments now,
 it lists the contents of `/Users/nelle/Desktop/data-shell/data`,
@@ -489,7 +489,7 @@ animals.txt       morse.txt     planets.txt     sunspot.txt
 {: .output}
 
 We now know how to go down the directory tree:
-how do we go up?  We might try the following: 
+how do we go up?  We might try the following:
 
 ~~~
 cd data-shell
@@ -503,13 +503,13 @@ cd data-shell
 
 But we get an error!  Why is this?  
 
-With our methods so far, 
-`cd` can only see sub-directories inside your current directory.  There are 
-different ways to see directories above your current location; we'll start 
+With our methods so far,
+`cd` can only see sub-directories inside your current directory.  There are
+different ways to see directories above your current location; we'll start
 with the simplest.  
 
 There is a shortcut in the shell to move up one directory level
-that looks like this: 
+that looks like this:
 
 ~~~
 $ cd ..
@@ -533,7 +533,7 @@ $ pwd
 ~~~
 {: .output}
 
-The special directory `..` doesn't usually show up when we run `ls`.  If we want 
+The special directory `..` doesn't usually show up when we run `ls`.  If we want
 to display it, we can give `ls` the `-a` flag:
 
 ~~~
@@ -559,7 +559,7 @@ It may seem redundant to have a name for it,
 but we'll see some uses for it soon.
 
 > ## Other Hidden Files
-> 
+>
 > In addition to the hidden directories `..` and `.`, you may also see a file
 > called `.bash_profile`. This file usually contains shell configuration
 > settings. You may also see other files and directories beginning
@@ -582,9 +582,9 @@ but we'll see some uses for it soon.
 > because there are fewer special cases and exceptions to keep track of.
 {: .callout}
 
-These then, are the basic commands for navigating the filesystem on your computer: 
-`pwd`, `ls` and `cd`.  Let's explore some variations on those commands.  What happens 
-if you type `cd` on its own, without giving 
+These then, are the basic commands for navigating the filesystem on your computer:
+`pwd`, `ls` and `cd`.  Let's explore some variations on those commands.  What happens
+if you type `cd` on its own, without giving
 a directory?  
 
 ~~~
@@ -604,12 +604,12 @@ $ pwd
 ~~~
 {: .output}
 
-It turns out that `cd` without an argument will return you to your home directory, 
+It turns out that `cd` without an argument will return you to your home directory,
 which is great if you've gotten lost in your own filesystem.  
 
-Let's try returning to the `data` directory from before.  Last time, we used 
-three commands, but we can actually string together the list of directories 
-to move to `data` in one step: 
+Let's try returning to the `data` directory from before.  Last time, we used
+three commands, but we can actually string together the list of directories
+to move to `data` in one step:
 
 ~~~
 $ cd Desktop/data-shell/data
@@ -618,24 +618,24 @@ $ cd Desktop/data-shell/data
 
 Check that we've moved to the right place by running `pwd` and `ls -F`.  
 
-If we want to move up one level from the shell directory, we could use `cd ..`.  But 
-there is another way to move to any directory, regardless of your 
+If we want to move up one level from the data directory, we could use `cd ..`.  But
+there is another way to move to any directory, regardless of your
 current location.  
 
-So far, when specifying directory names, or even a directory path (as above), 
-we have been using **relative paths**.  When you use a relative path with a command 
+So far, when specifying directory names, or even a directory path (as above),
+we have been using **relative paths**.  When you use a relative path with a command
 like `ls` or `cd`, it tries to find that location  from where we are,
 rather than from the root of the file system.  
 
-However, it is possible to specify the **absolute path** to a directory by 
-including its entire path from the root directory, which is indicated by a 
-leading slash.  The leading `/` tells the computer to follow the path from 
+However, it is possible to specify the **absolute path** to a directory by
+including its entire path from the root directory, which is indicated by a
+leading slash.  The leading `/` tells the computer to follow the path from
 the root of the file system, so it always refers to exactly one directory,
 no matter where we are when we run the command.
 
 This allows us to move to our `data-shell` directory from anywhere on
-the filesystem (including from inside `data`).  To find the absolute path 
-we're looking for, we can use `pwd` and then extract the piece we need 
+the filesystem (including from inside `data`).  To find the absolute path
+we're looking for, we can use `pwd` and then extract the piece we need
 to move to `data-shell`.  
 
 ~~~
@@ -661,13 +661,13 @@ Run `pwd` and `ls -F` to ensure that we're in the directory we expect.
 > mean "the current user's home directory". For example, if Nelle's home
 > directory is `/Users/nelle`, then `~/data` is equivalent to
 > `/Users/nelle/data`. This only works if it is the first character in the
-> path: `here/there/~/elsewhere` is *not* `here/there/Users/nelle/elsewhere`. 
-> 
+> path: `here/there/~/elsewhere` is *not* `here/there/Users/nelle/elsewhere`.
+>
 > Another shortcut is the `-` (dash) character.  `cd` will translate `-` into
-> *the previous directory I was in*, which is faster than having to remember, 
-> then type, the full path.  This is a *very* efficient way of moving back 
-> and forth between directories. The difference between `cd ..` and `cd -` is 
-> that the former brings you *up*, while the latter brings you *back*. 
+> *the previous directory I was in*, which is faster than having to remember,
+> then type, the full path.  This is a *very* efficient way of moving back
+> and forth between directories. The difference between `cd ..` and `cd -` is
+> that the former brings you *up*, while the latter brings you *back*.
 {: .callout}
 
 ### Nelle's Pipeline: Organizing Files
@@ -693,7 +693,7 @@ a directory called `revised-revised-results-3`.)
 > If she used month names,
 > December would come before July;
 > if she didn't use leading zeroes,
-> November ('11') would come before July ('7'). Similarly, putting the year first 
+> November ('11') would come before July ('7'). Similarly, putting the year first
 > means that June 2012 will come before June 2013.
 {: .callout}
 
@@ -744,10 +744,10 @@ and we will see it in many other tools as we go on.
 
 > ## Absolute vs Relative Paths
 >
-> Starting from `/Users/amanda/data/`, 
-> which of the following commands could Amanda use to navigate to her home directory, 
+> Starting from `/Users/amanda/data/`,
+> which of the following commands could Amanda use to navigate to her home directory,
 > which is `/Users/amanda`?
-> 
+>
 > 1. `cd .`
 > 2. `cd /`
 > 3. `cd /home/amanda`
@@ -773,7 +773,7 @@ and we will see it in many other tools as we go on.
 
 > ## Relative Path Resolution
 >
-> Using the filesystem diagram below, if `pwd` displays `/Users/thing`, 
+> Using the filesystem diagram below, if `pwd` displays `/Users/thing`,
 > what will `ls ../backup` display?
 >
 > 1.  `../backup: No such file or directory`
@@ -795,7 +795,7 @@ and we will see it in many other tools as we go on.
 
 > ## `ls` Reading Comprehension
 >
-> Assuming a directory structure as in the above Figure 
+> Assuming a directory structure as in the above Figure
 > (File System for Challenge Questions), if `pwd` displays `/Users/backup`,
 > and `-r` tells `ls` to display things in reverse order,
 > what command will display:
@@ -837,11 +837,11 @@ and we will see it in many other tools as we go on.
 
 > ## Listing Recursively and By Time
 >
-> The command `ls -R` lists the contents of directories recursively, i.e., lists 
-> their sub-directories, sub-sub-directories, and so on in alphabetical order 
-> at each level. The command `ls -t` lists things by time of last change, with 
+> The command `ls -R` lists the contents of directories recursively, i.e., lists
+> their sub-directories, sub-sub-directories, and so on in alphabetical order
+> at each level. The command `ls -t` lists things by time of last change, with
 > most recently changed files or directories first.
-> In what order does `ls -R -t` display things? Hint: `ls -l` uses a long listing 
+> In what order does `ls -R -t` display things? Hint: `ls -l` uses a long listing
 > format to view timestamps.
 >
 > > ## Solution
@@ -849,4 +849,3 @@ and we will see it in many other tools as we go on.
 > > in each directory are sorted by time of last change.
 > {: .solution}
 {: .challenge}
-

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -571,7 +571,7 @@ but we'll see some uses for it soon.
 
 > ## Orthogonality
 >
-> The special names `.` and `..` don't belong to `ls`;
+> The special names `.` and `..` don't belong to `cd`;
 > they are interpreted the same way by every program.
 > For example,
 > if we are in `/Users/nelle/data`,

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -110,7 +110,7 @@ molecules/  solar.pdf
 > or another non-alphanumeric character you should put quotes around the name.
 {: .callout}
 
-However, there's nothing in it yet:
+Since we've just created the `thesis` directory, there's nothing in it yet:
 
 ~~~
 $ ls -F thesis

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -595,9 +595,12 @@ but it does find the copy in `thesis` that we didn't delete.
 >
 > We have seen how to create text files using the `nano` editor.
 > Now, try the following command in your home directory:
-> 
+>
+> ~~~
 > $ cd                  # go to your home directory
 > $ touch my_file.txt
+> ~~~
+> {: .bash}
 >
 > 1.  What did the touch command do?
 >     When you look at your home directory using the GUI file explorer,

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -504,16 +504,18 @@ but it does find the copy in `thesis` that we didn't delete.
 > 4.   `proteins-saved.dat`
 >
 > > ## Solution
-> > We start in the /Users/jamie/data directory, and create a new folder called recombine.
-> > The second line moves (mv) the file proteins.dat to the new folder (recombine).
-> > The third line makes a copy of the file we just moved.  The tricky part here is where the file was 
-> > copied to.  Recall that .. means "go up a level", so the copied file is now in /Users/jamie.
-> > So, the only thing that will show using ls (in /Users/jamie/data) is the recombine folder.
-> > 
-> > 1. No, see explanation above.  proteins-saved.dat is located at /Users/jamie
+> > We start in the `/Users/jamie/data` directory, and create a new folder called `recombine`.
+> > The second line moves (`mv`) the file `proteins.dat` to the new folder (`recombine`).
+> > The third line makes a copy of the file we just moved.  The tricky part here is where the file was
+> > copied to.  Recall that `..` means "go up a level", so the copied file is now in `/Users/jamie`.
+> > Notice that `..` is interpreted with respect to the current working
+> > directory, **not** with respect to the location of the file being copied.
+> > So, the only thing that will show using ls (in `/Users/jamie/data`) is the recombine folder.
+> >
+> > 1. No, see explanation above.  `proteins-saved.dat` is located at `/Users/jamie`
 > > 2. Yes
-> > 3. No, see explanation above.  proteins.dat is located at /Users/jamie/data/recombine
-> > 4. No, see explanation above.  proteins-saved.dat is located at /Users/jamie
+> > 3. No, see explanation above.  `proteins.dat` is located at `/Users/jamie/data/recombine`
+> > 4. No, see explanation above.  `proteins-saved.dat` is located at `/Users/jamie`
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -137,8 +137,8 @@ $ nano draft.txt
 > [Vim](http://www.vim.org/) (both of which are completely unintuitive,
 > even by Unix standards), or a graphical editor such as
 > [Gedit](http://projects.gnome.org/gedit/). On Windows, you may wish to
-> use [Notepad++](http://notepad-plus-plus.org/).  Windows also has a built-in 
-> editor called `notepad` that can be run from the command line in the same 
+> use [Notepad++](http://notepad-plus-plus.org/).  Windows also has a built-in
+> editor called `notepad` that can be run from the command line in the same
 > way as `nano` for the purposes of this lesson.  
 >
 > No matter what editor you use, you will need to know where it searches
@@ -157,14 +157,14 @@ press Return to accept the suggested default of `draft.txt`).
 
 ![Nano in Action](../fig/nano-screenshot.png)
 
-Once our file is saved, we can use `Ctrl-X` to quit the editor and 
+Once our file is saved, we can use `Ctrl-X` to quit the editor and
 return to the shell.
 
 > ## Control, Ctrl, or ^ Key
 >
 > The Control key is also called the "Ctrl" key. There are various ways
 > in which using the Control key may be described. For example, you may
-> see an instruction to press the Control key and, while holding it down, 
+> see an instruction to press the Control key and, while holding it down,
 > press the X key, described as any of:
 >
 > * `Control-X`
@@ -175,7 +175,7 @@ return to the shell.
 >
 > In nano, along the bottom of the screen you'll see `^G Get Help ^O WriteOut`.
 > This means that you can use `Control-G` to get help and `Control-O` to save your
-> file. 
+> file.
 {: .callout}
 
 `nano` doesn't leave any output on the screen after it exits,
@@ -342,10 +342,10 @@ quotes.txt
 ~~~
 {: .output}
 
-One has to be careful when specifying the target file name, since `mv` will 
-silently overwrite any existing file with the same name, which could 
+One has to be careful when specifying the target file name, since `mv` will
+silently overwrite any existing file with the same name, which could
 lead to data loss. An additional flag, `mv -i` (or `mv --interactive`),
-can be used to make `mv` ask you for confirmation before overwriting. 
+can be used to make `mv` ask you for confirmation before overwriting.
 
 Just for the sake of inconsistency,
 `mv` also works on directories --- there is no separate `mvdir` command.
@@ -425,7 +425,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ## What's In A Name?
 >
 > You may have noticed that all of Nelle's files' names are "something dot
-> something", and in this part of the lesson, we always used the extension 
+> something", and in this part of the lesson, we always used the extension
 > `.txt`.  This is just a convention: we can call a file `mythesis` or
 > almost anything else we want. However, most people use two-part names
 > most of the time to help them (and their programs) tell different kinds
@@ -460,10 +460,10 @@ but it does find the copy in `thesis` that we didn't delete.
 > 4. `cp statstics.txt .`
 >
 > > ## Solution
-> > 1. No.  While this would create a file with the correct name, the incorrectly named file still exists in the directory 
+> > 1. No.  While this would create a file with the correct name, the incorrectly named file still exists in the directory
 > > and would need to be deleted.
 > > 2. Yes, this would work to rename the file.
-> > 3. No, the period(.) indicates where to move the file, but does not provide a new file name; identical file names 
+> > 3. No, the period(.) indicates where to move the file, but does not provide a new file name; identical file names
 > > cannot be created.
 > > 4. No, the period(.) indicates where to copy the file, but does not provide a new file name; identical file names
 > > cannot be created.
@@ -592,7 +592,7 @@ but it does find the copy in `thesis` that we didn't delete.
 {: .challenge}
 
 > ## Creating Files a Different Way
-> 
+>
 > We have seen how to create text files using the `nano` editor.
 > Now, try the following command in your home directory:
 > 
@@ -602,7 +602,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > 1.  What did the touch command do?
 >     When you look at your home directory using the GUI file explorer,
 >     does the file show up?
-> 
+>
 > 2.  Use `ls -l` to inspect the file's.  How large is `my_file.txt`?
 >
 > 3.  When might you want to create a file this way?
@@ -612,12 +612,12 @@ but it does find the copy in `thesis` that we didn't delete.
 >
 > After running the following commands,
 > Jamie realizes that she put the files `sucrose.dat` and `maltose.dat` into the wrong folder:
-> 
+>
 > ~~~
 > $ ls -F
 > raw/ analyzed/
 > $ ls -F analyzed
-> fructose.dat glucose.dat maltose.dat sucrose.dat 
+> fructose.dat glucose.dat maltose.dat sucrose.dat
 > $ cd raw/
 > ~~~
 > {: .bash}
@@ -644,22 +644,22 @@ but it does find the copy in `thesis` that we didn't delete.
 
 > ## Copy a folder structure sans files
 >
-> You're starting a new experiment, and would like to duplicate the file 
-> structure from your previous experiment without the data files so you can 
-> add new data. 
+> You're starting a new experiment, and would like to duplicate the file
+> structure from your previous experiment without the data files so you can
+> add new data.
 >
-> Assume that the file structure is in a folder called '2016-05-18-data', 
+> Assume that the file structure is in a folder called '2016-05-18-data',
 > which contains folders named 'raw' and 'processed' that contain data files.
 > The goal is to copy the file structure of the `2016-05-18-data` folder
-> into a folder called `2016-05-20-data` and remove the data files from 
+> into a folder called `2016-05-20-data` and remove the data files from
 > the directory you just created.
-> 
-> Which of the following set of commands would achieve this objective? 
+>
+> Which of the following set of commands would achieve this objective?
 > What would the other commands do?
 >
 > ~~~
-> $ cp -r 2016-05-18-data/ 2016-05-20-data/ 
-> $ rm 2016-05-20-data/data/raw/* 
+> $ cp -r 2016-05-18-data/ 2016-05-20-data/
+> $ rm 2016-05-20-data/data/raw/*
 > $ rm 2016-05-20-data/data/processed/*
 > ~~~
 > {: .bash}

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -225,6 +225,7 @@ and then move up one directory to `/Users/nelle/Desktop/data-shell` using `cd ..
 ~~~
 $ pwd
 ~~~
+{: .bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell/thesis

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -589,8 +589,6 @@ but it does find the copy in `thesis` that we didn't delete.
 > The command `ls -t` lists things by time of last change,
 > with most recently changed files or directories first.
 > In what order does `ls -R -t` display things?
-<<<<<<< b4a46c35a32b95aec05a70450e5bbaf8da924f86:_episodes/03-create.md
-<<<<<<< d4b00b24e33feb675b6a49e978763361959ea3c9:_episodes/03-create.md
 {: .challenge}
 
 > ## Creating Files a Different Way

--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -255,6 +255,7 @@ the output of `head` must be the file with the fewest lines.
 > Doing something like this may give you
 > incorrect results and/or delete
 > the contents of `lengths.txt`.
+{: .callout}
 
 If you think this is confusing,
 you're in good company:

--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -242,11 +242,11 @@ Since `sorted-lengths.txt` contains the lengths of our files ordered from least 
 the output of `head` must be the file with the fewest lines.
 
 > ## Redirecting to the same file
-> 
+>
 > It's a very bad idea to try redirecting
 > the output of a command that operates on a file
 > to the same file. For example:
-> 
+>
 > ~~~
 > $ sort -n lengths.txt > lengths.txt
 > ~~~
@@ -558,7 +558,7 @@ so this matches all the valid data files she has.
 {: .challenge}
 
 > ## More on Wildcards
-> 
+>
 > Sam has a directory containing calibration data, datasets, and descriptions of
 > the datasets:
 >
@@ -746,8 +746,8 @@ so this matches all the valid data files she has.
 
 > ## Appending Data
 >
-> Consider the file `animals.txt`, used in previous exercise. 
-> After these commands, select the alternative that 
+> Consider the file `animals.txt`, used in previous exercise.
+> After these commands, select the alternative that
 > corresponds the file `animalsUpd.txt`:
 >
 > ~~~
@@ -755,7 +755,7 @@ so this matches all the valid data files she has.
 > $ tail -2 animals.txt >> animalsUpd.txt
 > ~~~
 > {: .bash}
-> 
+>
 > 1. The first three lines of `animals.txt`
 > 2. The last two lines of `animals.txt`
 > 3. The first three lines and the last two lines of `animals.txt`


### PR DESCRIPTION
* some mild-to-moderate tweaks to aid clarity (segue after `mkdir` callouts, explanation of `..`, more thorough explanation in "Moving & Copying" challenge)
* formatting in "Moving & Copying" challenge
* remove cruft (duplicate "safe rm" challenge, lingering merge hash lines)
* several trailing whitespace removals
* add missing block type declarations to appease `make lesson-check`

Note: `make lesson-check` also complained about a couple unexpected SVG files.  They look to be ready to go, but I am assuming that they had not yet been integrated into the lesson for a good reason unknown to me, so I haven't changed the in-lesson references from PNG to SVG in this PR.

closes #466
