### PR TITLE
Add sentence equating ls -F -a to ls -Fa

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -549,6 +549,7 @@ Desktop/            north-pacific-gyre/ writing/
 ~~~
 {: .output}
 
+Note that `ls -Fa`is equivalent to `ls -F -a`, if you prefer to type fewer characters. 
 `-a` stands for "show all";
 it forces `ls` to show us file and directory names that begin with `.`,
 such as `..` (which, if we're in `/Users/nelle`, refers to the `/Users` directory)


### PR DESCRIPTION
This is a suggested change to address issue #464, and is part of my SWC instructor training checkout. I've added a single sentence to explain that shell flags can be concatenated if the learner wishes to type fewer characters. I appreciate any critical feedback!