### PR TITLE
Update 02-filedir.md

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -616,7 +616,7 @@ $ cd Desktop/data-shell/data
 ~~~
 {: .bash}
 
-Check that we've moved to the right place by running `pwd` and `ls -F`.  
+Check that we've moved to the right place by running `pwd` and `ls -F`  
 
 If we want to move up one level from the data directory, we could use `cd ..`.  But
 there is another way to move to any directory, regardless of your


### PR DESCRIPTION
The current listing of `ls -F`. on a physical printout makes it look like the command to be run is: `ls -F.`

This is incorrect as the period is intended to indicate the end of a sentence and not the special character `.` (current directory). It also may be unclear as a student might think they should be typing the following (valid) command: `ls -F .`

Recommendation: Remove all punctuation (periods, commas, semi-colons, etc.) after any command example for clarity in the documentation (both online and printed).