### PR TITLE
Delete `mvdir`

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -349,7 +349,7 @@ lead to data loss. An additional flag, `mv -i` (or `mv --interactive`),
 can be used to make `mv` ask you for confirmation before overwriting.
 
 Just for the sake of consistency,
-`mv` also works on directories --- there is no separate `mvdir` command.
+`mv` also works on directories
 
 Let's move `quotes.txt` into the current working directory.
 We use `mv` once again,


### PR DESCRIPTION
No need to mention lack of `mvdir` command since we didn't mention `rmdir`. Alternatively we could mention both.