### PR TITLE
Add VIM, Emacs and bash notation for control characters.

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -172,6 +172,7 @@ return to the shell.
 > * `Ctrl-X`
 > * `Ctrl+X`
 > * `^X`
+> * `C-x`
 >
 > In nano, along the bottom of the screen you'll see `^G Get Help ^O WriteOut`.
 > This means that you can use `Control-G` to get help and `Control-O` to save your


### PR DESCRIPTION
The current list of control key notations is missing the one commonly used by VIM, Emacs and some man pages (such as the bash man page). This commit adds that notation.

This pull request serves to fulfill my instructor training checkout requirement. 