### PR TITLE
Fixed an exercise in the episode on loops

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -526,10 +526,10 @@ so she decides to get some coffee and catch up on her reading.
 > In the same directory, what is the effect of this loop?
 >
 > ~~~
-> for species in *.pdb
+> for alkanes in *.pdb
 > do
->     echo $species
->     cat $species > alkanes.pdb
+>     echo $alkanes
+>     cat $alkanes > alkanes.pdb
 > done
 > ~~~
 > {: .bash}


### PR DESCRIPTION
Do not call variable `species` in a loop over alkanes.

This was spotted and fixed during the Software Carpentry workshop at St Andrews and was used as a demonstration how to submit a pull request.
