### PR TITLE
Solution to "Wildcard expressions": fix formatting, provide better answer

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -816,13 +816,12 @@ so this matches all the valid data files she has.
 >     where the original one would not?
 >
 > > ## Solution
-> > 1. 
-> >
 > > ```
 > > $ ls *A.txt
 > > $ ls *B.txt
 > > ```
 > > {: .bash}
+> > 1. Two expressions can be run as separate commands (or as one: `ls *A.txt *B.txt`). 
 > > 2. The output from the new commands is separated because there are two commands.
 > > 3. When there are no files ending in `A.txt`, or there are no files ending in
 > > `B.txt`.


### PR DESCRIPTION
Currently the solution is somewhat confusing for readers, because the numbered list is rendered as 1 1 2 instead of 1 2 3.  This is because a chunk of code appears between the first two answers and this disrupts the Markdown list syntax.  

I worked around this by putting the code chunk first.  

Also, I edited the first answer to point out that, although the solution seems to require 2 expressions, they can be executed in a single command: `ls *A.txt *B.txt` instead of `ls *A.txt` then `ls *B.txt`.  This will not generate an error in the case where one of the filename patterns has an empty expansion.  