### PR TITLE
-F in relative path exercise

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -818,12 +818,12 @@ and we will see it in many other tools as we go on.
 > ## Relative Path Resolution
 >
 > Using the filesystem diagram below, if `pwd` displays `/Users/thing`,
-> what will `ls ../backup` display?
+> what will `ls -F ../backup` display?
 >
 > 1.  `../backup: No such file or directory`
 > 2.  `2012-12-01 2013-01-08 2013-01-27`
 > 3.  `2012-12-01/ 2013-01-08/ 2013-01-27/`
-> 4.  `original pnas_final pnas_sub`
+> 4.  `original/ pnas_final/ pnas_sub/`
 >
 > ![File System for Challenge Questions](../fig/filesystem-challenge.svg)
 >
@@ -832,8 +832,7 @@ and we will see it in many other tools as we go on.
 > > 2. No: this is the content of `Users/thing/backup`,
 > >    but with `..` we asked for one level further up.
 > > 3. No: see previous explanation.
-> >    Also, we did not specify `-F` to display `/` at the end of the directory names.
-> > 4. Yes: `../backup` refers to `/Users/backup`.
+> > 4. Yes: `../backup/` refers to `/Users/backup/`.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
On a negative sticker, I got "the output of the quiz on relative path resolution isn't clear to windows users with no directory end slash (looks wrong)" So I edited the command to have the -F explicitly spelled out.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
