### PR TITLE
Update 04-pipefilter.md: correct 'Nelle’s Pipeline: Checking Files'

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -412,7 +412,7 @@ so that you and other people can put those programs into pipes to multiply their
 ## Nelle's Pipeline: Checking Files
 
 Nelle has run her samples through the assay machines
-and created 1520 files in the `north-pacific-gyre/2012-07-03` directory described earlier.
+and created 17 files in the `north-pacific-gyre/2012-07-03` directory described earlier.
 As a quick sanity check, starting from her home directory, Nelle types:
 
 ~~~
@@ -421,7 +421,7 @@ $ wc -l *.txt
 ~~~
 {: .bash}
 
-The output is 1520 lines that look like this:
+The output is 18 lines that look like this:
 
 ~~~
 300 NENE01729A.txt


### PR DESCRIPTION
Update 04-pipefilter.md: replace '1520' (2x) with '17' and '18, respectively.

The data-shell north-pacific-gyre/2012-07-03 folder contains a total of 19 files, 17 of which are .txt files. Using 'wc -l *.txt' will produce an output of 17 lines that lists these 17 files plus a line that lists the Total for a total number of line of 18. Given the lack of synch between the text mentioning '1520' lines and the real data file, I spent a good 20 minutes trying to figure out why my download did not show 1520 files. I now conclude that the number '1520' was used for dramatization purposes - but in my mind this is no justification for providing misleading information for novices.