### PR TITLE
Update 05-loop.md: lower case move commands

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -382,8 +382,8 @@ $ for datafile in NENE*[AB].txt; do echo $datafile; bash goostats $datafile stat
 
 > ## Beginning and End
 >
-> We can move to the beginning of a line in the shell by typing `Ctrl-A`
-> and to the end using `Ctrl-E`.
+> We can move to the beginning of a line in the shell by typing `Ctrl-a`
+> and to the end using `Ctrl-e`.
 {: .callout}
 
 When she runs her program now,


### PR DESCRIPTION
'Emacs' style move commands should be lower case, for these two, 'C-a' and 'C-e'.

....sorry about forgetting to delete the boiler plate message in my last submit. ;)