### PR TITLE
Update 07-find.md to fix capitalization

### DIFF
--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -636,7 +636,7 @@ about them."
 > > for sis in Jo Meg Beth Amy
 > > do
 > > 	echo $sis:
-> >	grep -ow $sis littlewomen.txt | wc -l
+> >	grep -ow $sis LittleWomen.txt | wc -l
 > > done
 > > ```
 > > {: .source}


### PR DESCRIPTION
In the solution to the first question about "Little Women", the file is not properly capitalized (and so the command would not work). This change corrects the capitalization of the file name.
