### PR TITLE
Updated CONTRIBUTING.rmd file instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,139 +1,62 @@
 # Contributing
 
-[Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects,
-and we welcome contributions of all kinds:
-new lessons,
-fixes to existing material,
-bug reports,
-and reviews of proposed changes are all welcome.
+[Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects, and we welcome contributions of all kinds: new lessons, fixes to existing material, bug reports, and reviews of proposed changes are all welcome.
 
 ## Contributor Agreement
 
-By contributing,
-you agree that we may redistribute your work under [our license](LICENSE.md).
-In exchange,
-we will address your issues and/or assess your change proposal as promptly as we can,
-and help you become a member of our community.
-Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+By contributing, you agree that we may redistribute your work under [our license](LICENSE.md). In exchange, we will address your issues and/or assess your change proposal as promptly as we can, and help you become a member of our community. Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site] agrees to abide by our [code of conduct](CONDUCT.md).
 
 ## How to Contribute
 
-The easiest way to get started is to file an issue
-to tell us about a spelling mistake,
-some awkward wording,
-or a factual error.
-This is a good way to introduce yourself
-and to meet some of our community members.
+The easiest way to get started is to file an issue to tell us about a spelling mistake, some awkward wording, or a factual error. This is a good way to introduce yourself and to meet some of our community members.
 
-1.  If you do not have a [GitHub][github] account,
-    you can [send us comments by email][contact].
-    However,
-    we will be able to respond more quickly if you use one of the other methods described below.
+1.  If you do not have a [GitHub][github] account, you can [send us comments by email][contact].
+However, we will be able to respond more quickly if you use one of the other methods described below.
 
-2.  If you have a [GitHub][github] account,
-    or are willing to [create one][github-join],
-    but do not know how to use Git,
-    you can report problems or suggest improvements by [creating an issue][issues].
-    This allows us to assign the item to someone
-    and to respond to it in a threaded discussion.
+2.  If you have a [GitHub][github] account, or are willing to [create one][github-join], but do not know how to use Git, you can report problems or suggest improvements by [creating an issue][issues]. This allows us to assign the item to someone and to respond to it in a threaded discussion.
 
-3.  If you are comfortable with Git,
-    and would like to add or change material,
-    you can submit a pull request (PR).
-    Instructions for doing this are [included below](#using-github).
+3.  If you are comfortable with Git, and would like to add or change material, you can submit a pull request (PR). Instructions for doing this are [included below](#using-github).
 
 ## Where to Contribute
 
-1.  If you wish to change this lesson,
-    please work in <https://github.com/swcarpentry/shell-novice>,
-    which can be viewed at <https://swcarpentry.github.io/shell-novice>.
+1.  If you wish to change this lesson, please work in <https://github.com/swcarpentry/shell-novice>, which can be viewed at <https://swcarpentry.github.io/shell-novice>.
 
-2.  If you wish to change the example lesson,
-    please work in <https://github.com/swcarpentry/lesson-example>,
-    which documents the format of our lessons
-    and can be viewed at <https://swcarpentry.github.io/lesson-example>.
+2.  If you wish to change the example lesson, please work in <https://github.com/swcarpentry/lesson-example>, which documents the format of our lessons and can be viewed at <https://swcarpentry.github.io/lesson-example>.
 
-3.  If you wish to change the template used for workshop websites,
-    please work in <https://github.com/swcarpentry/workshop-template>.
-    The home page of that repository explains how to set up workshop websites,
-    while the extra pages in <https://swcarpentry.github.io/workshop-template>
-    provide more background on our design choices.
+3.  If you wish to change the template used for workshop websites, please work in <https://github.com/swcarpentry/workshop-template>. The home page of that repository explains how to set up workshop websites, while the extra pages in <https://swcarpentry.github.io/workshop-template> provide more background on our design choices.
 
-4.  If you wish to change CSS style files, tools,
-    or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/swcarpentry/styles>.
+4.  If you wish to change CSS style files, tools, or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`, please work in <https://github.com/swcarpentry/styles>.
 
 ## What to Contribute
 
-There are many ways to contribute,
-from writing new exercises and improving existing ones
-to updating or filling in the documentation
-and submitting [bug reports][issues]
-about things that don't work, aren't clear, or are missing.
-If you are looking for ideas,
-please see [the list of issues for this repository][issues],
-or the issues for [Data Carpentry][dc-issues]
-and [Software Carpentry][swc-issues] projects.
+There are many ways to contribute, from writing new exercises and improving existing ones to updating or filling in the documentation and submitting [bug reports][issues] about things that don't work, aren't clear, or are missing. If you are looking for ideas, please see [the list of issues for this repository][issues], or the issues for [Data Carpentry][dc-issues] and [Software Carpentry][swc-issues] projects.
 
-Comments on issues and reviews of pull requests are just as welcome:
-we are smarter together than we are on our own.
-Reviews from novices and newcomers are particularly valuable:
-it's easy for people who have been using these lessons for a while
-to forget how impenetrable some of this material can be,
-so fresh eyes are always welcome.
+Comments on issues and reviews of pull requests are just as welcome: we are smarter together than we are on our own. Reviews from novices and newcomers are particularly valuable: it's easy for people who have been using these lessons for a while to forget how impenetrable some of this material can be, so fresh eyes are always welcome.
 
-## What *Not* to Contribute
+## What *NOT* to Contribute
 
-Our lessons already contain more material than we can cover in a typical workshop,
-so we are usually *not* looking for more concepts or tools to add to them.
-As a rule,
-if you want to introduce a new idea,
-you must (a) estimate how long it will take to teach
-and (b) explain what you would take out to make room for it.
-The first encourages contributors to be honest about requirements;
-the second, to think hard about priorities.
+Our lessons already contain more material than we can cover in a typical workshop, so we are usually *not* looking for more concepts or tools to add to them. As a rule, if you want to introduce a new idea, you must (a) estimate how long it will take to teach and (b) explain what you would take out to make room for it. The first encourages contributors to be honest about requirements; the second, to think hard about priorities.
 
-We are also not looking for exercises or other material that only run on one platform.
-Our workshops typically contain a mixture of Windows, Mac OS X, and Linux users;
-in order to be usable,
-our lessons must run equally well on all three.
+We are also not looking for exercises or other material that only run on one platform. Our workshops typically contain a mixture of Windows, Mac OS X, and Linux users; in order to be usable, our lessons must run equally well on all three.
 
 ## Using GitHub
 
-If you choose to contribute via GitHub,
-you may want to look at
-[How to Contribute to an Open Source Project on GitHub][how-contribute].
-In brief:
+If you choose to contribute via GitHub, you may want to look at [How to Contribute to an Open Source Project on GitHub][how-contribute]. A published copy of the lesson is available in the `gh-pages` branch of the [master repository][repo]. Before starting work, please make sure your clone of the master `gh-pages` branch is up-to-date and create your own revision-specific branch(es) from there. Please only work on your newly-created branch(es) and *not* your clone of the master `gh-pages` branch. To manage changes, we follow [GitHub flow][github-flow]. In brief:
 
-1.  The published copy of the lesson is in the `gh-pages` branch of the repository
-    (so that GitHub will regenerate it automatically).
-    Please create all branches from that,
-    and merge the [master repository][repo]'s `gh-pages` branch into your `gh-pages` branch
-    before starting work.
-    Please do *not* work directly in your `gh-pages` branch,
-    since that will make it difficult for you to work on other contributions.
+1.  Fork the repository to your GitHub profile and create a clone on your desktop.
+2.  Create a new branch in your desktop copy of this repository for each significant change being made.
+3.  Make revisions as required.
+4.  Stage all changed files and commit them within the appropriate branch.
+5.  Push any new branches to your forked copy of this repository on GitHub.
+6.  Submit a pull request from that branch to the [master repository][repo].
+7.  If you receive feedback, make changes using your desktop copy of the repository and push to your branch on GitHub. The pull request will update automatically.
+8.  Repeat as needed.
 
-2.  We use [GitHub flow][github-flow] to manage changes:
-    1.  Create a new branch in your desktop copy of this repository for each significant change.
-    2.  Commit the change in that branch.
-    3.  Push that branch to your fork of this repository on GitHub.
-    4.  Submit a pull request from that branch to the [master repository][repo].
-    5.  If you receive feedback,
-        make changes on your desktop and push to your branch on GitHub:
-        the pull request will update automatically.
-
-Each lesson has two maintainers who review issues and pull requests
-or encourage others to do so.
-The maintainers are community volunteers,
-and have final say over what gets merged into the lesson.
+Each lesson has two maintainers who review issues and pull requests or encourage others to do so. The maintainers are community volunteers and have final say over what gets merged into the lesson.
 
 ## Other Resources
 
-General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-happens on the [discussion mailing list][discuss-list],
-which everyone is welcome to join.
-You can also [reach us by email][contact].
+General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site] happens on the [discussion mailing list][discuss-list], which everyone is welcome to join. You can also [reach us by email][contact].
 
 [contact]: mailto:admin@software-carpentry.org
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
@@ -144,8 +67,8 @@ You can also [reach us by email][contact].
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/FIXME/issues/
-[repo]: https://github.com/swcarpentry/FIXME/
+[issues]: https://github.com/swcarpentry/shell-novice/issues
+[repo]: https://github.com/swcarpentry/shell-novice
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/
 [swc-site]: http://software-carpentry.org/


### PR DESCRIPTION
Removed excessive line breaks to make organization clearer for future modifications, made some small style revisions, clarified the instructions for how to contribute via GitHub, and fixed broken links to the repository.