### PR TITLE
Move explanation of goostats to loops episode

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -292,10 +292,15 @@ judicious use of `echo` is a good debugging technique.
 
 ## Nelle's Pipeline: Processing Files
 
-Nelle is now ready to process her data files.
+Nelle is now ready to process her data files using `goostats` --- a shell script written by her supervisor.
+This calculates some statistics from a protein sample file, and takes two arguments:
+
+1. an input file (containing the raw data)
+2. an output file (to store the calculated statistics)
+
 Since she's still learning how to use the shell,
 she decides to build up the required commands in stages.
-Her first step is to make sure that she can select the right files --- remember,
+Her first step is to make sure that she can select the right input files --- remember,
 these are ones whose names end in 'A' or 'B', rather than 'Z'. Starting from her home directory, Nelle types:
 
 ~~~

--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -321,9 +321,6 @@ The file `redo-figure-3.sh` now contains:
 {: .source}
 
 
-(`goostats` is a shell script which calculates some complicated statistics from a protein sample file -- the first argument -- and writes them to a file -- the second argument. 
-`goodiff`is a shell script for comparing statistics between two files, provides as arguments. Nelle's supervisor provided them without too many explanations.)
-
 After a moment's work in an editor to remove the serial numbers on the commands,
 and to remove the final line where we called the `history` command,
 we have a completely accurate record of how we created that figure.


### PR DESCRIPTION
This is where the shell script is first reintroduced so it makes
sense to put the explanation here.

Fix #653.