### PR TITLE
Move two exercises

### DIFF
--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -258,6 +258,109 @@ Miscellaneous:
 > matches an actual 'o'.
 {: .callout}
 
+> ## Tracking a Species
+> 
+> Leah has several hundred 
+> data files saved in one directory, each of which is formatted like this:
+> 
+> ~~~
+> 2013-11-05,deer,5
+> 2013-11-05,rabbit,22
+> 2013-11-05,raccoon,7
+> 2013-11-06,rabbit,19
+> 2013-11-06,deer,2
+> ~~~
+> {: .source}
+>
+> She wants to write a shell script that takes a species as the first command-line argument 
+> and a directory as the second argument. The script should return one file called `species.txt` 
+> containing a list of dates and the number of that species seen on each date.
+> For example using the data shown above, `rabbits.txt` would contain:
+> 
+> ~~~
+> 2013-11-05,22
+> 2013-11-06,19
+> ~~~
+> {: .source}
+>
+> Put these commands and pipes in the right order to achieve this:
+> 
+> ~~~
+> cut -d : -f 2  
+> >  
+> |  
+> grep -w $1 -r $2  
+> |  
+> $1.txt  
+> cut -d , -f 1,3  
+> ~~~
+> {: .bash}
+>
+> Hint: use `man grep` to look for how to grep text recursively in a directory
+> and `man cut` to select more than one field in a line.
+>
+> An example of such a file is provided in `data-shell/data/animal-counts/animals.txt`
+>
+> > ## Solution
+> >
+> > ```
+> > grep -w $1 -r $2 | cut -d : -f 2 | cut -d , -f 1,3  > $1.txt
+> > ```
+> > {: .source}
+> >
+> > You would call the script above like this:
+> >
+> > ```
+> > $ bash count-species.sh bear .
+> > ```
+> > {: .bash}
+> {: .solution}
+{: .challenge}
+
+> ## Little Women
+>
+> You and your friend, having just finished reading *Little Women* by
+> Louisa May Alcott, are in an argument.  Of the four sisters in the
+> book, Jo, Meg, Beth, and Amy, your friend thinks that Jo was the
+> most mentioned.  You, however, are certain it was Amy.  Luckily, you
+> have a file `LittleWomen.txt` containing the full text of the novel
+> (`data-shell/writing/data/LittleWomen.txt`).
+> Using a `for` loop, how would you tabulate the number of times each
+> of the four sisters is mentioned?
+>
+> Hint: one solution might employ
+> the commands `grep` and `wc` and a `|`, while another might utilize
+> `grep` options.
+> There is often more than one way to solve a programming task, so a
+> particular solution is usually chosen based on a combination of
+> yielding the correct result, elegance, readability, and speed.
+>
+> > ## Solutions
+> > ```
+> > for sis in Jo Meg Beth Amy
+> > do
+> > 	echo $sis:
+> >	grep -ow $sis LittleWomen.txt | wc -l
+> > done
+> > ```
+> > {: .source}
+> >
+> > Alternative, slightly inferior solution:
+> > ```
+> > for sis in Jo Meg Beth Amy
+> > do
+> > 	echo $sis:
+> >	grep -ocw $sis LittleWomen.txt
+> > done
+> > ```
+> > {: .source}
+> >
+> > This solution is inferior because `grep -c` only reports the number of lines matched.
+> > The total number of matches reported by this method will be lower if there is more
+> > than one match per line.
+> {: .solution}
+{: .challenge}
+
 While `grep` finds lines in files,
 the `find` command finds files themselves.
 Again,
@@ -552,109 +655,6 @@ about them."
 > >
 > > Option 3 is incorrect because it searches the contents of the files for lines which
 > > do not match "temp", rather than searching the file names.
-> {: .solution}
-{: .challenge}
-
-> ## Tracking a Species
-> 
-> Leah has several hundred 
-> data files saved in one directory, each of which is formatted like this:
-> 
-> ~~~
-> 2013-11-05,deer,5
-> 2013-11-05,rabbit,22
-> 2013-11-05,raccoon,7
-> 2013-11-06,rabbit,19
-> 2013-11-06,deer,2
-> ~~~
-> {: .source}
->
-> She wants to write a shell script that takes a species as the first command-line argument 
-> and a directory as the second argument. The script should return one file called `species.txt` 
-> containing a list of dates and the number of that species seen on each date.
-> For example using the data shown above, `rabbits.txt` would contain:
-> 
-> ~~~
-> 2013-11-05,22
-> 2013-11-06,19
-> ~~~
-> {: .source}
->
-> Put these commands and pipes in the right order to achieve this:
-> 
-> ~~~
-> cut -d : -f 2  
-> >  
-> |  
-> grep -w $1 -r $2  
-> |  
-> $1.txt  
-> cut -d , -f 1,3  
-> ~~~
-> {: .bash}
->
-> Hint: use `man grep` to look for how to grep text recursively in a directory
-> and `man cut` to select more than one field in a line.
->
-> An example of such a file is provided in `data-shell/data/animal-counts/animals.txt`
->
-> > ## Solution
-> >
-> > ```
-> > grep -w $1 -r $2 | cut -d : -f 2 | cut -d , -f 1,3  > $1.txt
-> > ```
-> > {: .source}
-> >
-> > You would call the script above like this:
-> >
-> > ```
-> > $ bash count-species.sh bear .
-> > ```
-> > {: .bash}
-> {: .solution}
-{: .challenge}
-
-> ## Little Women
->
-> You and your friend, having just finished reading *Little Women* by
-> Louisa May Alcott, are in an argument.  Of the four sisters in the
-> book, Jo, Meg, Beth, and Amy, your friend thinks that Jo was the
-> most mentioned.  You, however, are certain it was Amy.  Luckily, you
-> have a file `LittleWomen.txt` containing the full text of the novel
-> (`data-shell/writing/data/LittleWomen.txt`).
-> Using a `for` loop, how would you tabulate the number of times each
-> of the four sisters is mentioned?
->
-> Hint: one solution might employ
-> the commands `grep` and `wc` and a `|`, while another might utilize
-> `grep` options.
-> There is often more than one way to solve a programming task, so a
-> particular solution is usually chosen based on a combination of
-> yielding the correct result, elegance, readability, and speed.
->
-> > ## Solutions
-> > ```
-> > for sis in Jo Meg Beth Amy
-> > do
-> > 	echo $sis:
-> >	grep -ow $sis LittleWomen.txt | wc -l
-> > done
-> > ```
-> > {: .source}
-> >
-> > Alternative, slightly inferior solution:
-> > ```
-> > for sis in Jo Meg Beth Amy
-> > do
-> > 	echo $sis:
-> >	grep -ocw $sis LittleWomen.txt
-> > done
-> > ```
-> > {: .source}
-> >
-> > This solution is inferior because `grep -c` only reports the number of lines matched.
-> > The total number of matches reported by this method will be lower if there is more
-> > than one match per line.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Moves exercises "Tracking a Species" and "Little Women" to after `grep` and before `find` in the episode text.
