### PR TITLE
enable syntax highlighting for code snippets

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -54,7 +54,7 @@ let's open a shell window:
 ~~~
 $
 ~~~
-{: .bash}
+{: .language-bash}
 
 The dollar sign is a **prompt**, which shows us that the shell is waiting for input;
 your shell may use a different character as a prompt and may add information before
@@ -70,7 +70,7 @@ it shows us who the shell thinks we are:
 ~~~
 $ whoami
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 nelle
@@ -107,7 +107,7 @@ More specifically, when we type `whoami` the shell:
 > ~~~
 > $ mycommand
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > 
 > ~~~
 > -bash: mycommand: command not found
@@ -136,7 +136,7 @@ which is Nelle's **home directory**:
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle
@@ -211,7 +211,7 @@ which stands for "listing":
 ~~~
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Applications Documents    Library      Music        Public
@@ -232,7 +232,7 @@ which tells `ls` to add a trailing `/` to the names of directories:
 ~~~
 $ ls -F
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Applications/ Documents/    Library/      Music/        Public/
@@ -245,7 +245,7 @@ Desktop/      Downloads/    Movies/       Pictures/
 ~~~
 $ ls --help
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Usage: ls [OPTION]... [FILE]...
@@ -378,7 +378,7 @@ information on how to use the commands or programs.
 > ~~~
 > $ ls -j
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > 
 > ~~~
 > ls: invalid option -- 'j'
@@ -467,7 +467,7 @@ which doesn't exist.
 > ```
 > ls -lh Documents
 > ```
-> {: .bash}
+> {: .language-bash}
 > `ls` is the command, `-lh` are the flags (also called options),
 > and `Documents` is the argument.
 {: .callout}
@@ -482,7 +482,7 @@ we want a listing of something other than our current working directory:
 ~~~
 $ ls -F Desktop
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 data-shell/
@@ -510,7 +510,7 @@ a directory name to `ls`:
 ~~~
 $ ls -F Desktop/data-shell
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 creatures/          molecules/          notes.txt           solar.pdf
@@ -537,7 +537,7 @@ $ cd Desktop
 $ cd data-shell
 $ cd data
 ~~~
-{: .bash}
+{: .language-bash}
 
 These commands will move us from our home directory onto our Desktop, then into
 the `data-shell` directory, then into the `data` directory.  `cd` doesn't print anything,
@@ -550,7 +550,7 @@ because that's where we now are:
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell/data
@@ -560,7 +560,7 @@ $ pwd
 ~~~
 $ ls -F
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 amino-acids.txt   elements/     pdb/	        salmon.txt
@@ -574,7 +574,7 @@ how do we go up?  We might try the following:
 ~~~
 $ cd data-shell
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 -bash: cd: data-shell: No such file or directory
@@ -594,7 +594,7 @@ that looks like this:
 ~~~
 $ cd ..
 ~~~
-{: .bash}
+{: .language-bash}
 
 `..` is a special directory name meaning
 "the directory containing this one",
@@ -606,7 +606,7 @@ if we run `pwd` after running `cd ..`, we're back in `/Users/nelle/Desktop/data-
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell
@@ -619,7 +619,7 @@ to display it, we can give `ls` the `-a` flag:
 ~~~
 $ ls -F -a
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ./   .bash_profile  data/       north-pacific-gyre/  pizza.cfg  thesis/
@@ -672,14 +672,14 @@ a directory?
 ~~~
 $ cd
 ~~~
-{: .bash}
+{: .language-bash}
 
 How can you check what happened?  `pwd` gives us the answer!  
 
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle
@@ -696,7 +696,7 @@ to move to `data` in one step:
 ~~~
 $ cd Desktop/data-shell/data
 ~~~
-{: .bash}
+{: .language-bash}
 
 Check that we've moved to the right place by running `pwd` and `ls -F`  
 
@@ -723,7 +723,7 @@ to move to `data-shell`.
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell/data
@@ -733,7 +733,7 @@ $ pwd
 ~~~
 $ cd /Users/nelle/Desktop/data-shell
 ~~~
-{: .bash}
+{: .language-bash}
 
 Run `pwd` and `ls -F` to ensure that we're in the directory we expect.  
 
@@ -872,7 +872,7 @@ Nelle can see what files she has using the command:
 ~~~
 $ ls north-pacific-gyre/2012-07-03/
 ~~~
-{: .bash}
+{: .language-bash}
 
 This is a lot to type,
 but she can let the shell do most of the work through what is called **tab completion**.
@@ -881,7 +881,7 @@ If she types:
 ~~~
 $ ls nor
 ~~~
-{: .bash}
+{: .language-bash}
 
 and then presses tab (the tab key on her keyboard),
 the shell automatically completes the directory name for her:
@@ -889,7 +889,7 @@ the shell automatically completes the directory name for her:
 ~~~
 $ ls north-pacific-gyre/
 ~~~
-{: .bash}
+{: .language-bash}
 
 If she presses tab again,
 Bash will add `2012-07-03/` to the command,

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -27,7 +27,7 @@ and use `ls -F` to see what it contains:
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell
@@ -37,7 +37,7 @@ $ pwd
 ~~~
 $ ls -F
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg  solar.pdf  writing/
@@ -50,7 +50,7 @@ Let's create a new directory called `thesis` using the command `mkdir thesis`
 ~~~
 $ mkdir thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 As you might guess from its name,
 `mkdir` means "make directory".
@@ -61,7 +61,7 @@ the new directory is created in the current working directory:
 ~~~
 $ ls -F
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg  solar.pdf  thesis/  writing/
@@ -109,7 +109,7 @@ Since we've just created the `thesis` directory, there's nothing in it yet:
 ~~~
 $ ls -F thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 Let's change our working directory to `thesis` using `cd`,
 then run a text editor called Nano to create a file called `draft.txt`:
@@ -118,7 +118,7 @@ then run a text editor called Nano to create a file called `draft.txt`:
 $ cd thesis
 $ nano draft.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Which Editor?
 >
@@ -180,7 +180,7 @@ but `ls` now shows that we have created a file called `draft.txt`:
 ~~~
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 draft.txt
@@ -196,7 +196,7 @@ draft.txt
 > $ cd                  # go to your home directory
 > $ touch my_file.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1.  What did the touch command do?
 >     When you look at your home directory using the GUI file explorer,
@@ -231,7 +231,7 @@ Let's tidy up by running `rm draft.txt`:
 ~~~
 $ rm draft.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 This command removes files (`rm` is short for "remove").
 If we run `ls` again,
@@ -241,7 +241,7 @@ which tells us that our file is gone:
 ~~~
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Deleting Is Forever
 >
@@ -260,7 +260,7 @@ and then move up one directory to `/Users/nelle/Desktop/data-shell` using `cd ..
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell/thesis
@@ -271,7 +271,7 @@ $ pwd
 $ nano draft.txt
 $ ls
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 draft.txt
@@ -281,7 +281,7 @@ draft.txt
 ~~~
 $ cd ..
 ~~~
-{: .bash}
+{: .language-bash}
 
 If we try to remove the entire `thesis` directory using `rm thesis`,
 we get an error message:
@@ -289,7 +289,7 @@ we get an error message:
 ~~~
 $ rm thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 rm: cannot remove `thesis': Is a directory
@@ -304,7 +304,7 @@ We can do this with the [recursive](https://en.wikipedia.org/wiki/Recursion) opt
 ~~~
 $ rm -r thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Using `rm` Safely
 >
@@ -315,7 +315,7 @@ $ rm -r thesis
 > > ```
 > > $ rm: remove regular file 'thesis/quotations.txt'?
 > > ```
-> > {: .bash} 
+> > {: .language-bash} 
 > > The -i option will prompt before every removal. 
 > > The Unix shell doesn't have a trash bin, so all the files removed will disappear forever. 
 > > By using the -i flag, we have the chance to check that we are deleting only the files that we want to remove.
@@ -335,7 +335,7 @@ $ rm -r thesis
 > rm: remove regular file ‘thesis/draft.txt’? y
 > rm: remove directory ‘thesis’? y
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > This removes everything in the directory, then the directory itself, asking
 > at each step for you to confirm the deletion.
@@ -348,7 +348,7 @@ rather than going into the `thesis` directory and running `nano` on `draft.txt` 
 ~~~
 $ pwd
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 /Users/nelle/Desktop/data-shell
@@ -360,7 +360,7 @@ $ mkdir thesis
 $ nano thesis/draft.txt
 $ ls thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 draft.txt
@@ -374,7 +374,7 @@ which is short for "move":
 ~~~
 $ mv thesis/draft.txt thesis/quotes.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 The first argument tells `mv` what we're "moving",
 while the second is where it's to go.
@@ -387,7 +387,7 @@ Sure enough,
 ~~~
 $ ls thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 quotes.txt
@@ -414,7 +414,7 @@ the directory name we use is the special directory name `.` that we mentioned ea
 ~~~
 $ mv thesis/quotes.txt .
 ~~~
-{: .bash}
+{: .language-bash}
 
 The effect is to move the file from the directory it was in to the current working directory.
 `ls` now shows us that `thesis` is empty:
@@ -422,7 +422,7 @@ The effect is to move the file from the directory it was in to the current worki
 ~~~
 $ ls thesis
 ~~~
-{: .bash}
+{: .language-bash}
 
 Further,
 `ls` with a filename or directory name as an argument only lists that file or directory.
@@ -431,7 +431,7 @@ We can use this to see that `quotes.txt` is still in our current directory:
 ~~~
 $ ls quotes.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 quotes.txt
@@ -450,7 +450,7 @@ quotes.txt
 > fructose.dat glucose.dat maltose.dat sucrose.dat
 > $ cd raw/
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Fill in the blanks to move these files to the current folder
 > (i.e., the one she is currently in):
@@ -458,12 +458,12 @@ quotes.txt
 > ~~~
 > $ mv ___/sucrose.dat  ___/maltose.dat ___
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > > ## Solution
 > > ```
 > > $ mv ../analyzed/sucrose.dat ../analyzed/maltose.dat .
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > > Recall that `..` refers to the parent directory (i.e. one above the current directory)
 > > and that `.` refers to the current directory.
 > {: .solution}
@@ -479,7 +479,7 @@ with two paths as arguments --- like most Unix commands,
 $ cp quotes.txt thesis/quotations.txt
 $ ls quotes.txt thesis/quotations.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 quotes.txt   thesis/quotations.txt
@@ -494,7 +494,7 @@ and then run that same `ls` again.
 $ rm quotes.txt
 $ ls quotes.txt thesis/quotations.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ls: cannot access quotes.txt: No such file or directory
@@ -560,7 +560,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ~~~
 > $ pwd
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > /Users/jamie/data
 > ~~~
@@ -568,7 +568,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ~~~
 > $ ls
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > proteins.dat
 > ~~~
@@ -579,7 +579,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > $ cp recombine/proteins.dat ../proteins-saved.dat
 > $ ls
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1.   `proteins-saved.dat recombine`
 > 2.   `recombine`
@@ -610,7 +610,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ~~~
 > $ ls -F
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > analyzed/  fructose.dat    raw/   sucrose.dat
 > ~~~
@@ -623,7 +623,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ~~~
 > $ ls -F
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > analyzed/   raw/
 > ~~~
@@ -631,7 +631,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ~~~
 > $ ls analyzed
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > fructose.dat    sucrose.dat
 > ~~~
@@ -641,7 +641,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > > ```
 > > mv *.dat analyzed
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > > Jamie needs to move her files `fructose.dat` and `sucrose.dat` to the `analyzed` directory.
 > > The shell will expand *.dat to match all .dat files in the current directory.
 > > The `mv` command then moves the list of .dat files to the "analyzed" directory.
@@ -658,14 +658,14 @@ but it does find the copy in `thesis` that we didn't delete.
 > $ mkdir backup
 > $ cp amino-acids.txt animals.txt backup/
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > In the example below, what does `cp` do when given three or more file names?
 >
 > ~~~
 > $ ls -F
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > amino-acids.txt  animals.txt  backup/  elements/  morse.txt  pdb/  planets.txt  salmon.txt  sunspot.txt
 > ~~~
@@ -673,7 +673,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > ~~~
 > $ cp amino-acids.txt animals.txt morse.txt 
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solution
 > > If given more than one file name followed by a directory name (i.e. the destination directory must 
@@ -709,18 +709,18 @@ but it does find the copy in `thesis` that we didn't delete.
 > $ rm 2016-05-20-data/raw/*
 > $ rm 2016-05-20-data/processed/*
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > $ rm 2016-05-20-data/raw/*
 > $ rm 2016-05-20-data/processed/*
 > $ cp -r 2016-05-18-data/ 2016-5-20-data/
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 > $ cp -r 2016-05-18-data/ 2016-05-20-data/
 > $ rm -r -i 2016-05-20-data/
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > >
 > > ## Solution
 > > The first set of commands achieves this objective.

--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -34,7 +34,7 @@ a simple text format that specifies the type and position of each atom in the mo
 ~~~
 $ ls molecules
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 cubane.pdb    ethane.pdb    methane.pdb
@@ -52,7 +52,7 @@ so the shell turns `*.pdb` into a list of all `.pdb` files in the current direct
 $ cd molecules
 $ wc *.pdb
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
   20  156 1158 cubane.pdb
@@ -142,7 +142,7 @@ $ wc *.pdb
 > 2015-11-23-dataset2.txt
 > 2015-11-23-dataset_overview.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Before heading off to another field trip, she wants to back up her data and
 > send some datasets to her colleague Bob. Sam uses the following commands
@@ -154,7 +154,7 @@ $ wc *.pdb
 > $ cp 2015-____-____ ~/send_to_bob/all_november_files/
 > $ cp ____ ~/send_to_bob/all_datasets_created_on_a_23rd/
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Help Sam by filling in the blanks.
 >
@@ -164,7 +164,7 @@ $ wc *.pdb
 > > $ cp 2015-11-* ~/send_to_bob/all_november_files/
 > > $ cp *-23-dataset* ~send_to_bob/all_datasets_created_on_a_23rd/
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -174,7 +174,7 @@ the output shows only the number of lines per file:
 ~~~
 $ wc -l *.pdb
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
   20  cubane.pdb
@@ -198,7 +198,7 @@ Our first step toward a solution is to run the command:
 ~~~
 $ wc -l *.pdb > lengths.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 The greater than symbol, `>`, tells the shell to **redirect** the command's output
 to a file instead of printing it to the screen. (This is why there is no screen output:
@@ -212,7 +212,7 @@ some caution.
 ~~~
 $ ls lengths.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 lengths.txt
@@ -226,14 +226,14 @@ lengths.txt
 > ~~~
 > $ echo hello > testfile01.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > and:
 >
 > ~~~
 > $ echo hello >> testfile02.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Hint: Try executing each command twice in a row and then examining the output files.
 {: .challenge}
@@ -248,7 +248,7 @@ lengths.txt
 > $ head -3 animals.txt > animalsUpd.txt
 > $ tail -2 animals.txt >> animalsUpd.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1. The first three lines of `animals.txt`
 > 2. The last two lines of `animals.txt`
@@ -272,7 +272,7 @@ so `cat` just shows us what it contains:
 ~~~
 $ cat lengths.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
   20  cubane.pdb
@@ -348,7 +348,7 @@ instead, it sends the sorted result to the screen:
 ~~~
 $ sort -n lengths.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
   9  methane.pdb
@@ -371,7 +371,7 @@ we can run another command called `head` to get the first few lines in `sorted-l
 $ sort -n lengths.txt > sorted-lengths.txt
 $ head -n 1 sorted-lengths.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
   9  methane.pdb
@@ -394,7 +394,7 @@ the output of `head` must be the file with the fewest lines.
 > ~~~
 > $ sort -n lengths.txt > lengths.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Doing something like this may give you
 > incorrect results and/or delete
@@ -410,7 +410,7 @@ We can make it easier to understand by running `sort` and `head` together:
 ~~~
 $ sort -n lengths.txt | head -n 1
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
   9  methane.pdb
@@ -434,7 +434,7 @@ Thus we first use a pipe to send the output of `wc` to `sort`:
 ~~~
 $ wc -l *.pdb | sort -n
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
    9 methane.pdb
@@ -452,7 +452,7 @@ And now we send the output of this pipe, through another pipe, to `head`, so tha
 ~~~
 $ wc -l *.pdb | sort -n | head -n 1
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
    9  methane.pdb
@@ -566,14 +566,14 @@ so that you and other people can put those programs into pipes to multiply their
 > ~~~
 > $ wc -l notes.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > and:
 >
 > ~~~
 > $ wc -l < notes.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solution
 > > `<` is used to redirect input to a command. 
@@ -595,7 +595,7 @@ so that you and other people can put those programs into pipes to multiply their
 > > a test
 > > Ctrl-D # This lets the shell know you have finished typing the input
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > 3
@@ -625,7 +625,7 @@ so that you and other people can put those programs into pipes to multiply their
 > ~~~
 > $ cat animals.txt | head -n 5 | tail -n 3 | sort -r > final.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > Hint: build the pipeline up one command at a time to test your understanding
 {: .challenge}
 
@@ -662,7 +662,7 @@ so that you and other people can put those programs into pipes to multiply their
 > > ```
 > > $ sort salmon.txt | uniq
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -673,7 +673,7 @@ so that you and other people can put those programs into pipes to multiply their
 > ~~~
 > $ cut -d , -f 2 animals.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > produces the following output:
 >
@@ -697,7 +697,7 @@ so that you and other people can put those programs into pipes to multiply their
 > > ```
 > > $ cut -d , -f 2 animals.txt | sort | uniq
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -742,7 +742,7 @@ As a quick sanity check, starting from her home directory, Nelle types:
 $ cd north-pacific-gyre/2012-07-03
 $ wc -l *.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 The output is 18 lines that look like this:
 
@@ -762,7 +762,7 @@ Now she types this:
 ~~~
 $ wc -l *.txt | sort -n | head -n 5
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
  240 NENE02018B.txt
@@ -784,7 +784,7 @@ she checks to see if any files have too much data:
 ~~~
 $ wc -l *.txt | sort -n | tail -n 5
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
  300 NENE02040B.txt
@@ -804,7 +804,7 @@ To find others like it, she does this:
 ~~~
 $ ls *Z.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 NENE01971Z.txt    NENE02040Z.txt
@@ -852,7 +852,7 @@ so this matches all the valid data files she has.
 > > 	$ ls *A.txt
 > > 	$ ls *B.txt
 > > 	```
-> >	{: .bash}
+> >	{: .language-bash}
 > > 2. The output from the new commands is separated because there are two commands.
 > > 3. When there are no files ending in `A.txt`, or there are no files ending in
 > > `B.txt`.

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -36,14 +36,14 @@ We can't use:
 ~~~
 $ cp *.dat original-*.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 because that would expand to:
 
 ~~~
 $ cp basilisk.dat unicorn.dat original-*.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 This wouldn't back up our files, instead we get an error:
 
@@ -67,7 +67,7 @@ $ for filename in basilisk.dat unicorn.dat
 >    head -n 3 $filename
 > done
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 COMMON NAME: basilisk
@@ -126,7 +126,7 @@ name: `$filename` is equivalent to `${filename}`, but is different from
 >     ls *.pdb
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Now, what is the output of the following code?
 >
@@ -136,7 +136,7 @@ name: `$filename` is equivalent to `${filename}`, but is different from
 >	ls $datafile
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Why do these two loops give different outputs?
 >
@@ -153,7 +153,7 @@ name: `$filename` is equivalent to `${filename}`, but is different from
 > >	ls cubane.pdb  ethane.pdb  methane.pdb  octane.pdb  pentane.pdb  propane.pdb
 > > done
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > >
 > > ```
 > > cubane.pdb  ethane.pdb  methane.pdb  octane.pdb  pentane.pdb  propane.pdb
@@ -214,7 +214,7 @@ do
     head -n 3 $x
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 or:
 
@@ -224,7 +224,7 @@ do
     head -n 3 $temperature
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 it would work exactly the same way.
 *Don't do this.*
@@ -242,7 +242,7 @@ increase the odds that the program won't do what its readers think it does.
 >     ls $filename 
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1.  No files are listed.
 > 2.  All files are listed.
@@ -262,7 +262,7 @@ increase the odds that the program won't do what its readers think it does.
 >     ls $filename 
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1.  The same files would be listed.
 > 2.  All the files are listed this time.
@@ -286,7 +286,7 @@ do
     head -n 100 $filename | tail -n 20
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 The shell starts by expanding `*.dat` to create the list of files it will process.
 The **loop body**
@@ -297,7 +297,7 @@ For example:
 ~~~
 $ echo hello there
 ~~~
-{: .bash}
+{: .language-bash}
 
 prints:
 
@@ -318,7 +318,7 @@ do
     head -n 100 $filename | tail -n 20
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 because then the first time through the loop,
 when `$filename` expanded to `basilisk.dat`, the shell would try to run `basilisk.dat` as a program.
@@ -349,7 +349,7 @@ from whatever file is being processed
 >     head -n 100 "$filename" | tail -n 20
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > It is simpler just to avoid using whitespaces (or other special characters) in filenames.
 >
@@ -381,7 +381,7 @@ do
     cp $filename original-$filename
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 This loop runs the `cp` command once for each filename.
 The first time,
@@ -391,14 +391,14 @@ the shell executes:
 ~~~
 cp basilisk.dat original-basilisk.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 The second time, the command is:
 
 ~~~
 cp unicorn.dat original-unicorn.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 Since the `cp` command does not normally produce any output, it's hard to check 
 that the loop is doing the correct thing. By prefixing the command with `echo` 
@@ -428,7 +428,7 @@ $ for datafile in NENE*[AB].txt
 >     echo $datafile
 > done
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 NENE01729A.txt
@@ -451,7 +451,7 @@ $ for datafile in NENE*[AB].txt
 >     echo $datafile stats-$datafile
 > done
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 NENE01729A.txt stats-NENE01729A.txt
@@ -478,7 +478,7 @@ the shell redisplays the whole loop on one line
 ~~~
 $ for datafile in NENE*[AB].txt; do echo $datafile stats-$datafile; done
 ~~~
-{: .bash}
+{: .language-bash}
 
 Using the left arrow key,
 Nelle backs up and changes the command `echo` to `bash goostats`:
@@ -486,7 +486,7 @@ Nelle backs up and changes the command `echo` to `bash goostats`:
 ~~~
 $ for datafile in NENE*[AB].txt; do bash goostats $datafile stats-$datafile; done
 ~~~
-{: .bash}
+{: .language-bash}
 
 When she presses Enter,
 the shell runs the modified command.
@@ -500,7 +500,7 @@ and edits it to read:
 ~~~
 $ for datafile in NENE*[AB].txt; do echo $datafile; bash goostats $datafile stats-$datafile; done
 ~~~
-{: .bash}
+{: .language-bash}
 
 > ## Beginning and End
 >
@@ -540,7 +540,7 @@ so she decides to get some coffee and catch up on her reading.
 > ~~~
 > $ history | tail -n 5
 > ~~~
-> {: .bash}
+> {: .language-bash}
 > ~~~
 >   456  ls -l NENE0*.txt
 >   457  rm stats-NENE01729B.txt.txt
@@ -581,7 +581,7 @@ so she decides to get some coffee and catch up on her reading.
 >     cat $alkanes > alkanes.pdb
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1.  Prints `cubane.pdb`, `ethane.pdb`, `methane.pdb`, `octane.pdb`, `pentane.pdb` and `propane.pdb`,
 >     and the text from `propane.pdb` will be saved to a file called `alkanes.pdb`.
@@ -608,7 +608,7 @@ so she decides to get some coffee and catch up on her reading.
 >     cat $datafile >> all.pdb
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > 1.  All of the text from `cubane.pdb`, `ethane.pdb`, `methane.pdb`, `octane.pdb`, and
 >     `pentane.pdb` would be concatenated and saved to a file called `all.pdb`.
@@ -640,7 +640,7 @@ so she decides to get some coffee and catch up on her reading.
 >   analyze $file > analyzed-$file
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What is the difference between the two loops below, and which one would we
 > want to run?
@@ -652,7 +652,7 @@ so she decides to get some coffee and catch up on her reading.
 >   echo analyze $file > analyzed-$file
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > ~~~
 > # Version 2
@@ -661,7 +661,7 @@ so she decides to get some coffee and catch up on her reading.
 >   echo "analyze $file > analyzed-$file"
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solution
 > > The second version is the one we want to run.
@@ -693,7 +693,7 @@ so she decides to get some coffee and catch up on her reading.
 >     done
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solution
 > > We have a nested loop, i.e. contained within another loop, so for each species

--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -33,7 +33,7 @@ become our shell script:
 $ cd molecules
 $ nano middle.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 The command `nano middle.sh` opens the file `middle.sh` within the text editor "nano"
 (which runs within the shell).
@@ -61,7 +61,7 @@ Our shell is called `bash`, so we run the following command:
 ~~~
 $ bash middle.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ATOM      9  H           1      -4.502   0.681   0.785  1.00  0.00
@@ -96,7 +96,7 @@ Instead, let's edit `middle.sh` and make it more versatile:
 ~~~
 $ nano middle.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 Now, within "nano", replace the text `octane.pdb` with the special variable called `$1`:
 
@@ -112,7 +112,7 @@ We can now run our script like this:
 ~~~
 $ bash middle.sh octane.pdb
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ATOM      9  H           1      -4.502   0.681   0.785  1.00  0.00
@@ -128,7 +128,7 @@ or on a different file like this:
 ~~~
 $ bash middle.sh pentane.pdb
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ATOM      9  H           1       1.324   0.350  -1.332  1.00  0.00
@@ -154,7 +154,7 @@ number of lines to be passed to `head` and `tail` respectively:
 ~~~
 $ nano middle.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 head -n "$2" "$1" | tail -n "$3"
@@ -166,7 +166,7 @@ We can now run:
 ~~~
 $ bash middle.sh pentane.pdb 15 5
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ATOM      9  H           1       1.324   0.350  -1.332  1.00  0.00
@@ -183,7 +183,7 @@ behaviour:
 ~~~
 $ bash middle.sh pentane.pdb 20 5
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ATOM     14  H           1      -1.259   1.420   0.112  1.00  0.00
@@ -201,7 +201,7 @@ We can improve our script by adding some **comments** at the top:
 ~~~
 $ nano middle.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # Select lines from the middle of a file.
@@ -223,7 +223,7 @@ For example, if we want to sort our `.pdb` files by length, we would type:
 ~~~
 $ wc -l *.pdb | sort -n
 ~~~
-{: .bash}
+{: .language-bash}
 
 because `wc -l` lists the number of lines in the files
 (recall that `wc` stands for 'word count', adding the `-l` flag means 'count lines' instead)
@@ -245,7 +245,7 @@ Here's an example:
 ~~~
 $ nano sorted.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 # Sort filenames by their length.
@@ -257,7 +257,7 @@ wc -l "$@" | sort -n
 ~~~
 $ bash sorted.sh *.pdb ../creatures/*.dat
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 9 methane.pdb
@@ -320,7 +320,7 @@ $ bash sorted.sh *.pdb ../creatures/*.dat
 > ~~~
 > $ bash sorted.sh
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > but don't say `*.dat` (or anything else)? In this case, `$@` expands to
 > nothing at all, so the pipeline inside the script is effectively:
@@ -328,7 +328,7 @@ $ bash sorted.sh *.pdb ../creatures/*.dat
 > ~~~
 > $ wc -l | sort -n
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Since it doesn't have any filenames, `wc` assumes it is supposed to
 > process standard input, so it just sits there and waits for us to give
@@ -348,7 +348,7 @@ we can do this:
 ~~~
 $ history | tail -n 5 > redo-figure-3.sh
 ~~~
-{: .bash}
+{: .language-bash}
 
 The file `redo-figure-3.sh` now contains:
 
@@ -372,7 +372,7 @@ we have a completely accurate record of how we created that figure.
 > ~~~
 > $ history | tail -n 5 > recent.sh
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > the last command in the file is the `history` command itself, i.e.,
 > the shell has added `history` to the command log before actually
@@ -408,7 +408,7 @@ do
     bash goostats $datafile stats-$datafile
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 She saves this in a file called `do-stats.sh`
 so that she can now re-do the first stage of her analysis by typing:
@@ -416,14 +416,14 @@ so that she can now re-do the first stage of her analysis by typing:
 ~~~
 $ bash do-stats.sh NENE*[AB].txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 She can also do this:
 
 ~~~
 $ bash do-stats.sh NENE*[AB].txt | wc -l
 ~~~
-{: .bash}
+{: .language-bash}
 
 so that the output is just the number of files processed
 rather than the names of the files that were processed.
@@ -440,7 +440,7 @@ do
     bash goostats $datafile stats-$datafile
 done
 ~~~
-{: .bash}
+{: .language-bash}
 
 The advantage is that this always selects the right files:
 she doesn't have to remember to exclude the 'Z' files.
@@ -462,14 +462,14 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > head -n $2 $1
 > tail -n $3 $1
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > While you are in the `molecules` directory, you type the following command:
 >
 > ~~~
 > bash script.sh '*.pdb' 1 1
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Which of the following outputs would you expect to see?
 >
@@ -489,7 +489,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > > $ head -n 1 cubane.pdb ethane.pdb octane.pdb pentane.pdb propane.pdb
 > > $ tail -n 1 cubane.pdb ethane.pdb octane.pdb pentane.pdb propane.pdb
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > > The shell does not expand `'*.pdb'` because it is enclosed by quote marks.
 > > As such, the first argument to the script is `'*.pdb'` which gets expanded within the
 > > script by `head` and `tail`.
@@ -506,7 +506,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > ~~~
 > $ bash longest.sh /tmp/data pdb
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > would print the name of the `.pdb` file in `/tmp/data` that has
 > the most lines.
@@ -538,7 +538,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > # Script 1
 > echo *.*
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > ~~~
 > # Script 2
@@ -547,13 +547,13 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 >     cat $filename
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > ~~~
 > # Script 3
 > echo $@.pdb
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solutions
 > > Script 1 would print out a list of all files containing a dot in their name.
@@ -583,14 +583,14 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 >     bash goostats $datafile stats-$datafile
 > done
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > When you run it:
 >
 > ~~~
 > $ bash do-errors.sh NENE*[AB].txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > the output is blank.
 > To figure out why, re-run the script using the `-x` option:
@@ -598,7 +598,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > ~~~
 > bash -x do-errors.sh NENE*[AB].txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > What is the output showing you?
 > Which line is responsible for the error?

--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -36,7 +36,7 @@ $ cd
 $ cd writing
 $ cat haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 The Tao that is seen
@@ -65,7 +65,7 @@ Let's find lines that contain the word "not":
 ~~~
 $ grep not haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Is not the true Tao, until
@@ -83,7 +83,7 @@ Let's try a different pattern: "The".
 ~~~
 $ grep The haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 The Tao that is seen
@@ -103,7 +103,7 @@ This will limit matches to word boundaries.
 ~~~
 $ grep -w The haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 The Tao that is seen
@@ -119,7 +119,7 @@ want to search for a single word, but a phrase. This is also easy to do with
 ~~~
 $ grep -w "is not" haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Today it is not working
@@ -137,7 +137,7 @@ Another useful option is `-n`, which numbers the lines that match:
 ~~~
 $ grep -n "it" haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 5:With searching comes loss
@@ -155,7 +155,7 @@ the option `-w` to find the lines that contain the word "the" and `-n` to number
 ~~~
 $ grep -n -w "the" haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 2:Is not the true Tao, until
@@ -168,7 +168,7 @@ Now we want to use the option `-i` to make our search case-insensitive:
 ~~~
 $ grep -n -w -i "the" haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 1:The Tao that is seen
@@ -183,7 +183,7 @@ the lines that do not contain the word "the".
 ~~~
 $ grep -n -w -v "the" haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 1:The Tao that is seen
@@ -203,7 +203,7 @@ $ grep -n -w -v "the" haiku.txt
 ~~~
 $ grep --help
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 Usage: grep [OPTION]... PATTERN [FILE]...
@@ -261,7 +261,7 @@ Miscellaneous:
 > ~~~
 > $ grep -E '^.o' haiku.txt
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > ~~~
 > You bring fresh toner.
@@ -314,7 +314,7 @@ Miscellaneous:
 > $1.txt  
 > cut -d , -f 1,3  
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Hint: use `man grep` to look for how to grep text recursively in a directory
 > and `man cut` to select more than one field in a line.
@@ -333,7 +333,7 @@ Miscellaneous:
 > > ```
 > > $ bash count-species.sh bear .
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -401,7 +401,7 @@ let's run `find .`.
 ~~~
 $ find .
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 .
@@ -438,7 +438,7 @@ Sure enough,
 ~~~
 $ find . -type d
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ./
@@ -456,7 +456,7 @@ we get a listing of all the files instead:
 ~~~
 $ find . -type f
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ./haiku.txt
@@ -475,7 +475,7 @@ Now let's try matching by name:
 ~~~
 $ find . -name *.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ./haiku.txt
@@ -491,7 +491,7 @@ the command we actually ran was:
 ~~~
 $ find . -name haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 `find` did what we asked; we just asked for the wrong thing.
 
@@ -504,7 +504,7 @@ This way,
 ~~~
 $ find . -name '*.txt'
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ./data/one.txt
@@ -535,7 +535,7 @@ The simplest way is to put the `find` command inside `$()`:
 ~~~
 $ wc -l $(find . -name '*.txt')
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 11 ./haiku.txt
@@ -555,7 +555,7 @@ the shell constructs the command:
 ~~~
 $ wc -l ./data/one.txt ./data/LittleWomen.txt ./data/two.txt ./haiku.txt
 ~~~
-{: .bash}
+{: .language-bash}
 
 which is what we wanted.
 This expansion is exactly what the shell does when it expands wildcards like `*` and `?`,
@@ -570,7 +570,7 @@ by looking for the string "FE" in all the `.pdb` files above the current directo
 ~~~
 $ grep "FE" $(find .. -name '*.pdb')
 ~~~
-{: .bash}
+{: .language-bash}
 
 ~~~
 ../data/pdb/heme.pdb:ATOM     25 FE           1      -0.924   0.535  -0.518
@@ -647,7 +647,7 @@ about them."
 > ~~~
 > wc -l $(find . -name '*.dat') | sort -n
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > > ## Solution
 > > 1. Find all files with a `.dat` extension in the current directory
@@ -692,7 +692,7 @@ about them."
 > $1.txt  
 > cut -d , -f 1,3  
 > ~~~
-> {: .bash}
+> {: .language-bash}
 >
 > Hint: use `man grep` to look for how to grep text recursively in a directory
 > and `man cut` to select more than one field in a line.
@@ -711,7 +711,7 @@ about them."
 > > ```
 > > $ bash count-species.sh bear .
 > > ```
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}
 
@@ -777,6 +777,6 @@ about them."
 > > ~~~
 > > $ find ./ -type f -mtime -1 -user ahmed
 > > ~~~
-> > {: .bash}
+> > {: .language-bash}
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
I think the class that was being used (`.bash`) is out of date.

Fixes #687 