### PR TITLE
Edit to loops episode - spaces in names

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -362,7 +362,7 @@ from whatever file is being processed
 > ```
 > {: .output}
 > Try removing the quotes around `$filename` in the loop above to see the effect of the quote
-> marks on whitespace:
+> marks on whitespace. Note that we get a result from the loop command for unicorn.dat if you ran this code in the creatures directory:
 > ```
 > head: cannot open ‘red’ for reading: No such file or directory
 > head: cannot open ‘dragon.dat’ for reading: No such file or directory

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -367,8 +367,26 @@ from whatever file is being processed
 > head: cannot open ‘red’ for reading: No such file or directory
 > head: cannot open ‘dragon.dat’ for reading: No such file or directory
 > head: cannot open ‘purple’ for reading: No such file or directory
-
-> head: cannot open ‘unicorn.dat’ for reading: No such file or directory
+> CGGTACCGAA
+> AAGGGTCGCG
+> CAAGTGTTCC
+> CGGGACAATA
+> GTTCTGCTAA
+> GATAAGTATG
+> TGCCGACTTA
+> CCCGACCGTC
+> TAGGTTATAA
+> GGCACAACCG
+> CTTCACTGTA
+> GAGGTGTACA
+> AGGATCCGTT
+> GCGCGGGCGG
+> CAGTCTATGT
+> TTTTCGACAC
+> TGGACTGCTT
+> CCCTTTGAGG
+> GTGGATTTTT
+> CGTAACGGGT
 > ```
 > {: . output}
 {: .callout}

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -346,7 +346,7 @@ from whatever file is being processed
 > ~~~
 > for filename in "red dragon.dat" "purple unicorn.dat"
 > do
->     head -n 100 "$filename" | tail -n 20
+>     head -n 100 "$filename" | tail -n 3
 > done
 > ~~~
 > {: .language-bash}
@@ -362,7 +362,7 @@ from whatever file is being processed
 > ```
 > {: .output}
 > Try removing the quotes around `$filename` in the loop above to see the effect of the quote
-> marks on whitespace. Note that we get a result from the loop command for unicorn.dat if you ran this code in the creatures directory:
+> marks on whitespace. Note that we get a result from the loop command for unicorn.dat when we run this code in the `creatures` directory:
 > ```
 > head: cannot open ‘red’ for reading: No such file or directory
 > head: cannot open ‘dragon.dat’ for reading: No such file or directory
@@ -370,23 +370,6 @@ from whatever file is being processed
 > CGGTACCGAA
 > AAGGGTCGCG
 > CAAGTGTTCC
-> CGGGACAATA
-> GTTCTGCTAA
-> GATAAGTATG
-> TGCCGACTTA
-> CCCGACCGTC
-> TAGGTTATAA
-> GGCACAACCG
-> CTTCACTGTA
-> GAGGTGTACA
-> AGGATCCGTT
-> GCGCGGGCGG
-> CAGTCTATGT
-> TTTTCGACAC
-> TGGACTGCTT
-> CCCTTTGAGG
-> GTGGATTTTT
-> CGTAACGGGT
 > ```
 > {: . output}
 {: .callout}

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -367,6 +367,7 @@ from whatever file is being processed
 > head: cannot open ‘red’ for reading: No such file or directory
 > head: cannot open ‘dragon.dat’ for reading: No such file or directory
 > head: cannot open ‘purple’ for reading: No such file or directory
+
 > head: cannot open ‘unicorn.dat’ for reading: No such file or directory
 > ```
 > {: . output}


### PR DESCRIPTION
I made some edits to the Loops episode based on this issue: Unix shell Loops 'Spaces in Names' section #712. Assuming the learner tests the 'red dragon.dat' and 'purple unicorn.dat' loop in the creatures directory, they will get an output from unicorn.dat. I've edited the output and added a sentence to explain why there is a result. 
