### PR TITLE
Clarify example's intended use of mv

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -577,7 +577,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > {: .output}
 > ~~~
 > $ mkdir recombine
-> $ mv proteins.dat recombine
+> $ mv proteins.dat recombine/
 > $ cp recombine/proteins.dat ../proteins-saved.dat
 > $ ls
 > ~~~


### PR DESCRIPTION
This confuses some learners each time I teach it (including this morning), since `mv` is overloaded (moving and renaming), 

When I instruct `mv`, I recommend adding a trailing slash (as in the change) when you intend to move a file. Then, if a path is mistyped, `mv` will not try to rename a file to the incorrectly typed path. 

I think adding the slash here clarifies the intent of `mv`. 

(The trailing `/` also would show up if you were to "Tab-complete" `recombine`. )

