### PR TITLE
Removed 'ls is alphabetical by default'

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -137,13 +137,12 @@ Desktop      Downloads    Movies       Pictures
 (Again, your results may be slightly different depending on your operating
 system and how you have customized your filesystem.)
 
-`ls` prints the names of the files and directories in the current directory in
-alphabetical order, arranged neatly into columns.
+`ls` prints the names of the files and directories in the current directory. 
 We can make its output more comprehensible by using the **flag** `-F`
 (also known as a **switch** or an **option**) ,
 which tells `ls` to add a marker to file and directory names to indicate what
 they are. A trailing `/` indicates that this is a directory. Depending on your
-terminal, it might also use colors to indicate whether each entry is a file or 
+settings, it might also use colors to indicate whether each entry is a file or 
 directory.
 You might recall that we used `ls -F` in an earlier example.
 
@@ -377,15 +376,14 @@ To **quit** the `man` pages, press `q`.
 > ## Listing Recursively and By Time
 >
 > The command `ls -R` lists the contents of directories recursively, i.e., lists
-> their sub-directories, sub-sub-directories, and so on in alphabetical order
-> at each level. The command `ls -t` lists things by time of last change, with
-> most recently changed files or directories first.
+> their sub-directories, sub-sub-directories, and so on at each level. The command
+> `ls -t` lists things by time of last change, with most recently changed files or
+> directories first.
 > In what order does `ls -R -t` display things? Hint: `ls -l` uses a long listing
 > format to view timestamps.
 >
 > > ## Solution
-> > The directories are listed alphabetical at each level, the files/directories
-> > in each directory are sorted by time of last change.
+> > The files/directories in each directory are sorted by time of last change.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
This is only the case with the GNU implementation - the BSD version of ls (which is the default on OSX, for example) does not list files alphabetically.  The POSIX standard explicitly says the output formatting for terminals and the ordering is implementation specific (non-terminal output is guaranteed to be one file per line).

This change therefore addresses both the misinformation that ls always lists alphabetically by default and improves POSIX compliance of the text (for which there is also an outstanding issue).

I have also changed the word 'terminal' to 'settings', where is says the output may or may not be coloured by default - again this it determined by more than just the terminal supporting and having colour enabled (most importantly by where 'ls' has be aliased to a default set of flags including the colour one - RedHat do this but Debian do not, for example) so to say it is just the terminal is misleading - I believe substituting this word addresses the inaccuracy without reducing understandability or increasing the complexity of the material.

Fixes #744.  References #708.
