### PR TITLE
Fixing formatting error

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -652,7 +652,7 @@ but it does find the copy in `thesis` that we didn't delete.
 
 > ## Copy with Multiple Filenames
 >
-> For this exercise, you can test the commands in the `data-shell/data directory`.
+> For this exercise, you can test the commands in the `data-shell/data` directory.
 >
 > In the example below, what does `cp` do when given several filenames and a directory name?
 >


### PR DESCRIPTION
The word "directory" was being displayed in blue like its a command when it shouldn't be.
