### PR TITLE
Extended the example of errors in use of ls 

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -333,6 +333,19 @@ or available locally via: info '(coreutils) ls invocation'
 > Try 'ls --help' for more information.
 > ~~~
 > {: .error}
+> Note the differences between this error and the type we saw earlier:
+>
+> ~~~
+> $ ls-j
+> ~~~
+> {: .language-bash}
+> 
+> ~~~
+> -bash: ls-j: command not found
+> ~~~
+> {: .error}
+> The errors have two different sources - the ls program and bash,
+> indicated at the start of the error message.
 {: .callout}
 
 #### The `man` command


### PR DESCRIPTION
to illustrate the difference in form of output when the errors come from bash
(caused by a typo) compared to when the errors come from a program (caused
by incorrect arguments).

