### PR TITLE
Updated 03-create.md to create a file before demonstrating safe deletion

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -312,12 +312,19 @@ $ rm -r thesis
 
 > ## Using `rm` Safely
 >
-> What happens when we type `rm -i thesis/quotations.txt`?
+> Let's create a file called delete_me.txt:
+>
+> ~~~
+> touch delete_me.txt
+> ~~~
+> {: .language-bash}
+>
+> What happens when we type `rm -i delete_me.txt`?
 > Why would we want this protection when using `rm`?
 >
 > > ## Solution
 > > ```
-> > $ rm: remove regular file 'thesis/quotations.txt'?
+> > $ rm: remove regular file 'delete_me.txt'?
 > > ```
 > > {: .language-bash} 
 > > The -i option will prompt before every removal. 


### PR DESCRIPTION
This PR resolves issue #794 to create a new file before using `rm -i` on it since `thesis/quotations.txt` doesn't exist at this point in the lesson.