### PR TITLE
[fix #849] Fix minor typo in goostats usage info

### DIFF
--- a/data-shell/north-pacific-gyre/2012-07-03/goostats
+++ b/data-shell/north-pacific-gyre/2012-07-03/goostats
@@ -1,7 +1,7 @@
 # check for the right number of input arguments
 if [ $# -ne 2 ]
   then
-    echo "goodstats file1 file2"
+    echo "goostats file1 file2"
     echo "call goostats with two arguments"
     exit 1
 fi


### PR DESCRIPTION
Replaced one occurrence of 'goodstats' with 'goostats'
in the usage information for the goostats script that's
included in the data-shell sample data set.