### PR TITLE
Edited The Unix Shell: Loops

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -307,7 +307,7 @@ the output of `head` must be the file with the fewest lines.
 > > Option 3 is correct. 
 > > For option 1 to be correct we would only run the `head` command.
 > > For option 2 to be correct we would only run the `tail` command.
-> > For option 4 to be correct we would have to pipe the output of `head` into `tail -2` by doing `head -3 animals.txt | tail -2 >> animalsUpd.txt`
+> > For option 4 to be correct we would have to pipe the output of `head` into `tail -2` by doing `head -3 animals.txt | tail -2 > animalsUpd.txt`
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -31,31 +31,24 @@ we'll use the `creatures` directory which only has two example files,
 but the principles can be applied to many many more files at once.
 We would like to modify these files, but also save a version of the original files, naming the copies
 `original-basilisk.dat` and `original-unicorn.dat`.
-We can't use:
 
 ~~~
-$ cp *.dat original-*.dat
+$ mv basilisk.dat original-basilisk.dat
+$ mv unicorn.dat original-unicorn.dat
+
 ~~~
 {: .language-bash}
 
-because that would expand to:
-
+Now we want to extract the first three lines of these files
+We can use 
 ~~~
-$ cp basilisk.dat unicorn.dat original-*.dat
+$ head -n3 original-basilisk.dat
+$ head -n3 original-unicorn.dat
+
 ~~~
 {: .language-bash}
 
-This wouldn't back up our files, instead we get an error:
-
-~~~
-cp: target `original-*.dat' is not a directory
-~~~
-{: .error}
-
-This problem arises when `cp` receives more than two inputs. When this happens, it
-expects the last input to be a directory where it can copy all the files it was passed.
-Since there is no directory named `original-*.dat` in the `creatures` directory we get an
-error.
+This would be easy for only 2 files but gets complicated if you are dealing with multiple files
 
 Instead, we can use a **loop**
 to do some operation once for each thing in a list.


### PR DESCRIPTION
The loop lesson starts with cp command error which can be covered in the navigation lesson. This lesson should start with the head -n3 command for the individual files and the use of loop command to circumvent using individual commands for each file.