### PR TITLE
Fixes for "Creating files a different way"

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -215,7 +215,7 @@ draft.txt
 >
 > > ## Solution
 > > 1.  The `touch` command generates a new file called `my_file.txt` in
-> >     your home directory.  If you are in your home directory, you
+> >     your current directory.  You
 > >     can observe this newly generated file by typing `ls` at the 
 > >     command line prompt.  `my_file.txt` can also be viewed in your
 > >     GUI file explorer.

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -195,7 +195,7 @@ draft.txt
 ~~~
 {: .output}
 
-> ## Creating files a different way
+> ## Creating Files a Different Way
 >
 > We have seen how to create text files using the `nano` editor.
 > Now, try the following command:

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -195,18 +195,17 @@ draft.txt
 ~~~
 {: .output}
 
-> ## Creating Files a Different Way
+> ## Creating files a different way
 >
 > We have seen how to create text files using the `nano` editor.
-> Now, try the following command in your home directory:
+> Now, try the following command:
 >
 > ~~~
-> $ cd                  # go to your home directory
 > $ touch my_file.txt
 > ~~~
 > {: .language-bash}
 >
-> 1.  What did the touch command do?
+> 1.  What did the `touch` command do?
 >     When you look at your home directory using the GUI file explorer,
 >     does the file show up?
 >
@@ -215,15 +214,15 @@ draft.txt
 > 3.  When might you want to create a file this way?
 >
 > > ## Solution
-> > 1.  The touch command generates a new file called 'my_file.txt' in
+> > 1.  The `touch` command generates a new file called `my_file.txt` in
 > >     your home directory.  If you are in your home directory, you
 > >     can observe this newly generated file by typing `ls` at the 
-> >     command line prompt.  'my_file.txt' can also be viewed in your
+> >     command line prompt.  `my_file.txt` can also be viewed in your
 > >     GUI file explorer.
 > >
 > > 2.  When you inspect the file with `ls -l`, note that the size of
-> >     'my_file.txt' is 0kb.  In other words, it contains no data.
-> >     If you open 'my_file.txt' using your text editor it is blank.
+> >     `my_file.txt` is 0 bytes.  In other words, it contains no data.
+> >     If you open `my_file.txt` using your text editor it is blank.
 > >
 > > 3.  Some programs do not generate output files themselves, but
 > >     instead require that empty files have already been generated.
@@ -413,7 +412,7 @@ lead to data loss. An additional flag, `mv -i` (or `mv --interactive`),
 can be used to make `mv` ask you for confirmation before overwriting.
 
 Just for the sake of consistency,
-`mv` also works on directories
+`mv` also works on directories.
 
 Let's move `quotes.txt` into the current working directory.
 We use `mv` once again,


### PR DESCRIPTION
- No need to go to the home directory
- Enclose `touch` and `my_file.txt` in tick marks
- Use "0 bytes" instead of "0kb" for the empty file size

Also add a missing period in "Moving files and directories".