### PR TITLE
Fixes for "Creating files a different way" 

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -198,15 +198,14 @@ draft.txt
 > ## Creating Files a Different Way
 >
 > We have seen how to create text files using the `nano` editor.
-> Now, try the following command in your home directory:
+> Now, try the following command:
 >
 > ~~~
-> $ cd                  # go to your home directory
 > $ touch my_file.txt
 > ~~~
 > {: .language-bash}
 >
-> 1.  What did the touch command do?
+> 1.  What did the `touch` command do?
 >     When you look at your home directory using the GUI file explorer,
 >     does the file show up?
 >
@@ -215,15 +214,15 @@ draft.txt
 > 3.  When might you want to create a file this way?
 >
 > > ## Solution
-> > 1.  The touch command generates a new file called 'my_file.txt' in
+> > 1.  The `touch` command generates a new file called `my_file.txt` in
 > >     your home directory.  If you are in your home directory, you
 > >     can observe this newly generated file by typing `ls` at the 
-> >     command line prompt.  'my_file.txt' can also be viewed in your
+> >     command line prompt.  `my_file.txt` can also be viewed in your
 > >     GUI file explorer.
 > >
 > > 2.  When you inspect the file with `ls -l`, note that the size of
-> >     'my_file.txt' is 0kb.  In other words, it contains no data.
-> >     If you open 'my_file.txt' using your text editor it is blank.
+> >     `my_file.txt` is 0 bytes.  In other words, it contains no data.
+> >     If you open `my_file.txt` using your text editor it is blank.
 > >
 > > 3.  Some programs do not generate output files themselves, but
 > >     instead require that empty files have already been generated.

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -215,7 +215,7 @@ draft.txt
 >
 > > ## Solution
 > > 1.  The `touch` command generates a new file called `my_file.txt` in
-> >     your home directory.  If you are in your home directory, you
+> >     your current directory.  You
 > >     can observe this newly generated file by typing `ls` at the 
 > >     command line prompt.  `my_file.txt` can also be viewed in your
 > >     GUI file explorer.

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -206,7 +206,7 @@ draft.txt
 > {: .language-bash}
 >
 > 1.  What did the `touch` command do?
->     When you look at your home directory using the GUI file explorer,
+>     When you look at your current directory using the GUI file explorer,
 >     does the file show up?
 >
 > 2.  Use `ls -l` to inspect the files.  How large is `my_file.txt`?


### PR DESCRIPTION
- No need to go to the home directory
- Enclose `touch` and `my_file.txt` in tick marks
- Use "0 bytes" instead of "0kb" for the empty file size

Supersedes https://github.com/swcarpentry/shell-novice/pull/902 , rebasing it on top of #887.