### PR TITLE
'ls' can have multiple file arguments. And cut 'splits' not 'separates'

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -614,7 +614,7 @@ so that you and other people can put those programs into pipes to multiply their
 > ~~~
 > {: .language-bash}
 > 
-> uses the `-d` flag to separate each line by comma, and the `-f` flag
+> uses the `-d` flag to each line by comma, and the `-f` flag
 > to print the second field in each line, to give the following output:
 >
 > ~~~
@@ -775,27 +775,15 @@ so this matches all the valid data files she has.
 > this.
 >
 > 1.  Can you match the same set of files with basic wildcard expressions
->     that do not use the `[]` syntax? *Hint*: You may need more than one
->     expression.
->
-> 2.  The expression that you found and the expression from the lesson match the
->     same set of files in this example. What is the small difference between the
->     outputs?
->
-> 3.  Under what circumstances would your new expression produce an error message
->     where the original one would not?
+>     that do not use the `[]` syntax?
 >
 > > ## Solution
 > > 1. 
 > >
 > > 	```
-> > 	$ ls *A.txt
-> > 	$ ls *B.txt
+> > 	$ ls *A.txt *B.txt
 > > 	```
 > >	{: .language-bash}
-> > 2. The output from the new commands is separated because there are two commands.
-> > 3. When there are no files ending in `A.txt`, or there are no files ending in
-> > `B.txt`.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
instead of the 2 calls with a bigger chance of an error

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
