### PR TITLE
Render letter keys as lower-case

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -347,10 +347,10 @@ of how to use it.
 
 To navigate through the `man` pages,
 you may use <kbd>↑</kbd> and <kbd>↓</kbd> to move line-by-line,
-or try <kbd>B</kbd> and <kbd>Spacebar</kbd> to skip up and down by a full page.
+or try <kbd>b</kbd> and <kbd>Spacebar</kbd> to skip up and down by a full page.
 To search for a character or word in the `man` pages, 
 use <kbd>/</kbd> followed by the character or word you are searching for. 
-Sometimes a search will result in multiple hits.  If so, you can move between hits using <kbd>N</kbd> (for moving forward) and <kbd>Shift</kbd>+<kbd>N</kbd> (for moving backward).
+Sometimes a search will result in multiple hits.  If so, you can move between hits using <kbd>n</kbd> (for moving forward) and <kbd>Shift</kbd>+<kbd>n</kbd> (for moving backward).
 
 To **quit** the `man` pages, press <kbd>Q</kbd>. 
 


### PR DESCRIPTION
Adjusting case of hotkeys used in man (technically less).

It could be confusing for new users to read a capital B in the text when we really mean a lowercase b, and later use the notation of Shift-B to mean an actual capital B.

There are other places this could be adjusted (q versus Q or ctrl-o versus ctrl-O, for example), but I've avoided changing anything that works, even if it's not the default that most people would use.