### PR TITLE
Include definition of delimiter in episode 4

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -577,7 +577,7 @@ so that you and other people can put those programs into pipes to multiply their
 > ~~~
 > {: .language-bash}
 >
-> The `cut` command is used to remove or "cut out" certain sections of each line in the file. The optional `-d` flag is used to define the delimiter. The default delimiter is <kbd>Tab</kbd>. The `-f` flag is used to specify the field (column) to cut out.
+> The `cut` command is used to remove or "cut out" certain sections of each line in the file. The optional `-d` flag is used to define the delimiter. A **delimiter** is a character that is used to separate each line of text into columns. The default delimiter is <kbd>Tab</kbd>, meaning that the `cut` command will automatically assume that values in different columns will be separated by a tab. The `-f` flag is used to specify the field (column) to cut out.
 > The command above uses the `-d` option to split each line by comma, and the `-f` option
 > to print the second field in each line, to give the following output:
 >


### PR DESCRIPTION
In episode 4, the term "delimiter" was used without being defined previously. How the -d option is used in the cut command is described briefly, but the actual meaning of the word wasn't included. I added a definition of what a delimiter is and an explanation of what it means in the context of the cut command.