### PR TITLE
Clarify learning objective in 07-find.md

### DIFF
--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -7,7 +7,7 @@ questions:
 - "How can I find things in files?"
 objectives:
 - "Use `grep` to select lines from text files that match simple patterns."
-- "Use `find` to find files whose names match simple patterns."
+- "Use `find` to find files and directories whose names match simple patterns."
 - "Use the output of one command as the command-line argument(s) to another command."
 - "Explain what is meant by 'text' and 'binary' files, and why many common tools don't handle the latter well."
 keypoints:


### PR DESCRIPTION
What changed?: Revised Learning Objective #2 to reflect that the "find" command can also be used for directories (one of the examples in the lesson uses the "$ find . -type d" command)

What specifically changed?:
Revised:
"Use `find` to find files whose names match simple patterns." 
to:
"Use `find` to find files and directories whose names match simple patterns."