### PR TITLE
Remove `<` operator from Episode 4 objectives

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -18,7 +18,6 @@ keypoints:
 - "`wc` counts lines, words, and characters in its inputs."
 - "`command > file` redirects a command's output to a file (overwriting any existing content)."
 - "`command >> file` appends a command's output to a file."
-- "`<` operator redirects input to a command"
 - "`first | second` is a pipeline: the output of the first command is used as the input to the second."
 - "The best way to use the shell is to use pipes to combine simple single-purpose programs (filters)."
 ---


### PR DESCRIPTION
The material for the `<` operator was removed awhile ago from the
episode 4 lesson plan, but the objectives were overlooked. Remove
the bullet point for the `<` operator from the objectives so that
it no longer appears in the Key Points section for Pipes and
Filters.

Please see issue #1015 for more context.