### PR TITLE
Included a sentence for wc command in 04-pipefilter.md

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -46,7 +46,7 @@ Let's go into that directory with `cd` and run the command `wc *.pdb`.
 it counts the number of lines, words, and characters in files (from left to right, in that order).
 
 The `*` in `*.pdb` matches zero or more characters,
-so the shell turns `*.pdb` into a list of all `.pdb` files in the current directory:
+so the shell turns `*.pdb` into a list of all `.pdb` files in the current directory. Note that `wc *.pdb` also shows the total number of all lines in the last line of the output.
 
 ~~~
 $ cd molecules


### PR DESCRIPTION
Included one sentence just after the sentence "The * in *.pdb matches zero or more characters ...... in the current directory" to mention about the total number of lines in the last line of the output from "wc *.pdb".

I think including this information in the description will make it more clear for the readers.
