### PR TITLE
Simpler example to mv files to a new directory

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -336,30 +336,30 @@ quotes.txt
 ~~~
 {: .output}
 
-> ## Moving to the Current Folder
+> ## Moving Files to a new folder
 >
 > After running the following commands,
-> Jamie realizes that she put the files `sucrose.dat` and `maltose.dat` into the wrong folder:
+> Jamie realizes that she put the files `sucrose.dat` and `maltose.dat` into the wrong folder.  The files should have been placed in the raw folder.
 >
 > ~~~
 > $ ls -F
 >  analyzed/ raw/
 > $ ls -F analyzed
 > fructose.dat glucose.dat maltose.dat sucrose.dat
-> $ cd raw/
+> $ cd analyzed
 > ~~~
 > {: .language-bash}
 >
-> Fill in the blanks to move these files to the current folder
-> (i.e., the one she is currently in):
+> Fill in the blanks to move these files to the raw/ folder
+> (i.e. the one she forgot to put them in) 
 >
 > ~~~
-> $ mv ___/sucrose.dat  ___/maltose.dat ___
+> $ mv sucrose.dat maltose.dat ____/____
 > ~~~
 > {: .language-bash}
 > > ## Solution
 > > ```
-> > $ mv ../analyzed/sucrose.dat ../analyzed/maltose.dat .
+> > $ mv sucrose.dat maltose.dat ../raw
 > > ```
 > > {: .language-bash}
 > > Recall that `..` refers to the parent directory (i.e. one above the current directory)


### PR DESCRIPTION
The example of moving files to the current directory could seem overly complicated to someone who is new to the shell.  I felt like a better way to solve a problem like this would be to show you can cd into the directory you misplaced the files in and using the mv command put the multiple files on one line pointing to the new directory.   So the solution for getting the files into the raw/ folder would be: 
$ cd analyzed
$ mv sucrose.dat maltose.dat ../raw

Seems much simpler this way.  I would also reinforce to students the importance of tab completion.   At the very least, it'd be good to show this method as an alternative to the solution provided.
