### PR TITLE
Updating Apple operating system references to "macOS"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ The first encourages contributors to be honest about requirements;
 the second, to think hard about priorities.
 
 We are also not looking for exercises or other material that only run on one platform.
-Our workshops typically contain a mixture of Windows, Mac OS X, and Linux users;
+Our workshops typically contain a mixture of Windows, macOS, and Linux users;
 in order to be usable,
 our lessons must run equally well on all three.
 

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -135,7 +135,7 @@ $ nano draft.txt
 > human-friendly media. We use it in examples because it is one of the
 > least complex text editors. However, because of this trait, it may
 > not be powerful enough or flexible enough for the work you need to do
-> after this workshop. On Unix systems (such as Linux and Mac OS X),
+> after this workshop. On Unix systems (such as Linux and macOS),
 > many programmers use [Emacs](http://www.gnu.org/software/emacs/) or
 > [Vim](http://www.vim.org/) (both of which require more time to learn),
 > or a graphical editor such as

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -213,7 +213,7 @@ as long as learners using Windows do not run into roadblocks such as:
 
 *  Stay within POSIX-compliant commands, as all the teaching materials do.
    Your particular shell may have extensions beyond POSIX that are not available
-   on other machines, especially the default OSX bash and Windows bash emulators.
+   on other machines, especially the default macOS bash and Windows bash emulators.
    For example, POSIX `ls` does not have an `--ignore=` or `-I` option, and POSIX
    `head` takes `-n 10` or `-10`, but not the long form of `--lines=10`.
 

--- a/bin/boilerplate/CONTRIBUTING.md
+++ b/bin/boilerplate/CONTRIBUTING.md
@@ -95,7 +95,7 @@ The first encourages contributors to be honest about requirements;
 the second, to think hard about priorities.
 
 We are also not looking for exercises or other material that only run on one platform.
-Our workshops typically contain a mixture of Windows, Mac OS X, and Linux users;
+Our workshops typically contain a mixture of Windows, macOS, and Linux users;
 in order to be usable,
 our lessons must run equally well on all three.
 

--- a/reference.md
+++ b/reference.md
@@ -116,7 +116,7 @@ MIME type
 
 operating system
 :   Software that manages interactions between users, hardware, and software [processes](#process). Common
-    examples are Linux, OS X, and Windows.
+    examples are Linux, macOS, and Windows.
 
 orthogonal
 :   To have meanings or behaviors that are independent of each other.
@@ -180,7 +180,7 @@ relative path
 
 root directory
 :   The top-most directory in a [file system](#file-system).
-    Its name is "/" on Unix (including Linux and Mac OS X) and "\\" on Microsoft Windows.
+    Its name is "/" on Unix (including Linux and macOS) and "\\" on Microsoft Windows.
 
 shell
 :   A [command-line interface](#cli) such as Bash (the Bourne-Again Shell)

--- a/setup.md
+++ b/setup.md
@@ -29,7 +29,7 @@ In the lesson, you will find out how to access the data in this folder.
 > which can be found via the applications menu or the search bar.
 > If your machine is set up to use something other than bash, you can run it by opening a terminal and typing `bash`.
 >
-> ### Mac OS
+> ### macOS
 > For a Mac computer, the default Unix Shell is Bash,
 > and it is available via the Terminal Utilities program within your Applications folder.
 >


### PR DESCRIPTION
"macOS" has been the name since 2016, and [Wikipedia](https://en.wikipedia.org/wiki/MacOS_version_history) doesn't capitalize it at the start of a sentence. I think I caught all the variants of OSX, OS X, Mac OS, etc.