### PR TITLE
cd command out of place

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -44,6 +44,7 @@ octane.pdb    pentane.pdb   propane.pdb
 Let's go into that directory with `cd` and run the command `wc cubane.pdb`:
 
 ~~~
+$ cd molecules
 $ wc cubane.pdb 
 ~~~
 {: .language-bash}
@@ -60,7 +61,6 @@ If we run the command `wc *.pdb`, the `*` in `*.pdb` matches zero or more charac
 so the shell turns `*.pdb` into a list of all `.pdb` files in the current directory:
 
 ~~~
-$ cd molecules
 $ wc *.pdb
 ~~~
 {: .language-bash}


### PR DESCRIPTION
The cd command is mentioned in the text in a different place than it is issued in the code snippets

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
