### PR TITLE
Fixing capitalization of Ctrl-r and adding more detailed explanation

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -18,7 +18,7 @@ keypoints:
 - "Do not use spaces, quotes, or wildcard characters such as '*' or '?' in filenames, as it complicates variable expansion."
 - "Give files consistent names that are easy to match with wildcard patterns to make it easy to select them for looping."
 - "Use the up-arrow key to scroll up through previous commands to edit and repeat them."
-- "Use `Ctrl-R` to search through the previously entered commands."
+- "Use `Ctrl-r` to search through the previously entered commands."
 - "Use `history` to display recent commands, and `!number` to repeat a command by number."
 ---
 
@@ -585,7 +585,7 @@ the shell runs the modified command.
 However, nothing appears to happen --- there is no output.
 After a moment, Nelle realizes that since her script doesn't print anything to the screen any longer,
 she has no idea whether it is running, much less how quickly.
-She kills the running command by typing `Ctrl-C`,
+She kills the running command by typing `Ctrl-c`,
 uses up-arrow to repeat the command,
 and edits it to read:
 
@@ -650,9 +650,15 @@ so she decides to get some coffee and catch up on her reading.
 >
 > There are a number of other shortcut commands for getting at the history.
 >
-> - `Ctrl-R` enters a history search mode 'reverse-i-search' and finds the
+> - `Ctrl-r` enters a history search mode 'reverse-i-search' and finds the
 > most recent command in your history that matches the text you enter next.
-> Press `Ctrl-R` one or more additional times to search for earlier matches.
+> Press `Ctrl-r` one or more additional times to search for earlier matches.
+> You can then use the left and right arrow keys to choose that line and edit
+> it then hit <kbd>return</kbd> to run the command.
+> - `!head:p` will print the last command that starts with 'head' or any other
+> command you want to search for and prints it to the screen.  That command is 
+> also inserted as the last entry in the history list so you can access it with
+> the up arrow key, modify it if needed, then hit <kbd>return</kbd> to run it.
 > - `!!` retrieves the immediately preceding command
 > (you may or may not find this more convenient than using the up-arrow)
 > - `!$` retrieves the last word of the last command.
@@ -716,7 +722,7 @@ so she decides to get some coffee and catch up on her reading.
 
 > ## Nested Loops
 >
-> Suppose we want to set up up a directory structure to organize
+> Suppose we want to set up a directory structure to organize
 > some experiments measuring reaction rate constants with different compounds
 > *and* different temperatures.  What would be the
 > result of the following code:


### PR DESCRIPTION
Ctrl-R doesn't work on all OS's while Ctrl-r does and is less ambiguous.

Same for Ctrl-C, using Ctrl-c is clearer

I also added an extra example of using the history command

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
