### PR TITLE
Fix formatting of keyboard key combinations

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -153,22 +153,23 @@ $ nano draft.txt
 {: .callout}
 
 Let's type in a few lines of text.
-Once we're happy with our text, we can press <kbd>Ctrl</kbd>+<kbd>O</kbd> (press the Ctrl or Control key and, while
-holding it down, press the O key) to write our data to disk
+Once we're happy with our text, we can press <kbd>Ctrl</kbd>+<kbd>O</kbd>
+(press the <kbd>Ctrl</kbd> or <kbd>Control</kbd> key and, while
+holding it down, press the <kbd>O</kbd> key) to write our data to disk
 (we'll be asked what file we want to save this to:
 press <kbd>Return</kbd> to accept the suggested default of `draft.txt`).
 
 <div style="width:80%; margin: auto;"><img alt="Nano in Action" src="../fig/nano-screenshot.png"></div>
 
-Once our file is saved, we can use `Ctrl-X` to quit the editor and
+Once our file is saved, we can use <kbd>Ctrl</kbd>+<kbd>X</kbd> to quit the editor and
 return to the shell.
 
 > ## Control, Ctrl, or ^ Key
 >
 > The Control key is also called the 'Ctrl' key. There are various ways
 > in which using the Control key may be described. For example, you may
-> see an instruction to press the Control key and, while holding it down,
-> press the X key, described as any of:
+> see an instruction to press the <kbd>Control</kbd> key and, while holding it down,
+> press the <kbd>X</kbd> key, described as any of:
 >
 > * `Control-X`
 > * `Control+X`

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -596,8 +596,8 @@ $ for datafile in NENE*[AB].txt; do echo $datafile; bash goostats $datafile stat
 
 > ## Beginning and End
 >
-> We can move to the beginning of a line in the shell by typing `Ctrl-a`
-> and to the end using `Ctrl-e`.
+> We can move to the beginning of a line in the shell by typing `Ctrl-A`
+> and to the end using `Ctrl-E`.
 {: .callout}
 
 When she runs her program now,

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -596,8 +596,8 @@ $ for datafile in NENE*[AB].txt; do echo $datafile; bash goostats $datafile stat
 
 > ## Beginning and End
 >
-> We can move to the beginning of a line in the shell by typing `Ctrl-A`
-> and to the end using `Ctrl-E`.
+> We can move to the beginning of a line in the shell by typing <kbd>Ctrl</kbd>+<kbd>A</kbd>
+> and to the end using <kbd>Ctrl</kbd>+<kbd>E</kbd>.
 {: .callout}
 
 When she runs her program now,


### PR DESCRIPTION
Use keyboard symbols for keys users should press,
and upper case when referring to letter keys.

Fix #1069.