### PR TITLE
small change to specify that the "molecules" directory is in the main data-shell directory

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -25,7 +25,7 @@ keypoints:
 Now that we know a few basic commands,
 we can finally look at the shell's most powerful feature:
 the ease with which it lets us combine existing programs in new ways.
-We'll start with a directory called `molecules`
+We'll start with the directory called `data-shell/molecules`
 that contains six files describing some simple organic molecules.
 The `.pdb` extension indicates that these files are in Protein Data Bank format,
 a simple text format that specifies the type and position of each atom in the molecule.


### PR DESCRIPTION

small change to specify that the "molecules" directory is in the main "data-shell" directory. This is in line with the examples at the end of the previous lesson. It is aimed to minimize confusion for students.