### PR TITLE
Change wc option -c (byte count) to -m (char count)

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -97,7 +97,7 @@ $ wc -l *.pdb
 ~~~
 {: .output}
 
-The `-c` and `-w` options can also be used with the `wc` command, to show 
+The `-m` and `-w` options can also be used with the `wc` command, to show 
 only the number of characters or the number of words in the files.
 
 > ## Why Isn't It Doing Anything?


### PR DESCRIPTION
Closes swcarpentry/shell-novice#1073

The wc command option -c counts bytes, not characters. The correct option for character count is -m.