### PR TITLE
Edit in command not found message, in case the program corresponding to that command is not installed or mis-typed.

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -101,7 +101,7 @@ Documents   Library     Music       Public
 > ~~~
 > {: .output}
 >
-> Usually this means that you have mis-typed the command.
+> Usually this means that you have mis-typed the command. You get the same error, when you type the tool command but the tool has not been installed.
 {: .callout}
 
 


### PR DESCRIPTION
Typing a misspelled command gives "Command not found error", however, in cases where tool is not installed, you may still get "Command not found error" and I think the beginners should know this as well.