### PR TITLE
Episode 6: clarify "longest file" solution

### DIFF
--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -511,6 +511,17 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > > wc -l $1/*.$2 | sort -n | tail -n 2 | head -n 1
 > > ```
 > > {: .source}
+> >
+> > The first part of the pipeline, `wc -l $1/*.$2 | sort -n`, counts
+> > the lines in each file and sorts them numerically (largest last). When
+> > there's more than one file, `wc` also outputs a final summary line,
+> > giving the total number of lines across _all_ files.  We use `tail
+> > -n 2 | head -n 1` to throw away this last line.
+> >
+> > With `wc -l $1/*.$2 | sort -n | tail -n 1` we'll see the final summary
+> > line: we can build our pipeline up in pieces to be sure we understand
+> > the output.
+> >
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Address #1014

The solution script to determine the longest file has no explanation:
add a reminder that `wc` outputs a line with totals for more than one
file.  We can also build pipelines up to be certain we know what is
output at each stage.