### PR TITLE
Modified redirects and pipes image to SVG format

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -419,7 +419,7 @@ the calculation is 'head of sort of line count of `*.pdb`'.
 
 The redirection and pipes used in the last few commands are illustrated below:
 
-![Redirects and Pipes](../fig/redirects-and-pipes.png)
+![Redirects and Pipes](../fig/redirects-and-pipes.svg)
 
 > ## Piping Commands Together
 >


### PR DESCRIPTION
Changed the code to reflect the redirects-and-pipes.svg instead of the original redirects-and-pipes.png.

