### PR TITLE
Improve consistency of wording

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -440,12 +440,12 @@ To **quit** the `man` pages, press <kbd>Q</kbd>.
 
 > ## Listing in Reverse Chronological Order
 >
-> By default `ls` lists the contents of a directory in alphabetical 
-> order by name. The command `ls -t` lists items by time of last 
-> change instead of alphabetically. The command `ls -r` lists the 
+> By default `ls` lists the contents of a directory in alphabetical
+> order by name. The command `ls -t` lists items by time of last
+> change instead of alphabetically. The command `ls -r` lists the
 > contents of a directory in reverse order.
-> Which file is displayed last when you combine the `-t` and `-r` flags? 
-> Hint: You may need to use the `-l` flag to see the 
+> Which file is displayed last when you combine the `-t` and `-r` flags?
+> Hint: You may need to use the `-l` flag to see the
 > last changed dates.
 >
 > > ## Solution
@@ -474,8 +474,8 @@ data-shell/
 ~~~
 {: .output}
 
-Your output should be a list of all the files and sub-directories on your
-Desktop, including the `data-shell` directory you downloaded at
+Your output should be a list of all the files and sub-directories in your
+Desktop directory, including the `data-shell` directory you downloaded at
 the [setup for this lesson]({{ page.root }}{% link setup.md %}).  Take a look at your Desktop to confirm that
 your output is accurate.
 
@@ -486,7 +486,7 @@ it's possible to put hundreds of files in our home directory,
 just as it's possible to pile hundreds of printed papers on our desk,
 but it's a self-defeating strategy.
 
-Now that we know the `data-shell` directory is located on our Desktop, we
+Now that we know the `data-shell` directory is located in our Desktop directory, we
 can do two things.
 
 First, we can look at its contents, using the same strategy as before, passing
@@ -524,7 +524,7 @@ $ cd data
 ~~~
 {: .language-bash}
 
-These commands will move us from our home directory onto our Desktop, then into
+These commands will move us from our home directory into our Desktop directory, then into
 the `data-shell` directory, then into the `data` directory.  You will notice that `cd` doesn't print anything.  This is normal.  Many shell commands will not output anything to the screen when successfully executed.  But if we run `pwd` after it, we can see that we are now
 in `/Users/nelle/Desktop/data-shell/data`.
 If we run `ls` without arguments now,


### PR DESCRIPTION
Change "onto Desktop" to "into Desktop directory" to make it more command-line centric.

Part of #1099.