### PR TITLE
fix link to "Bash Configurations Demystified" post

### DIFF
--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -68,4 +68,4 @@ This excellent blog post "[Bash Configurations Demystified][bash-demystified]"
 from Dalton Hubble
 covers tips, tricks, and how to avoid dangers.
 
-[bash-demystified]: https://blog.dghubble.io/post/.bashprofile-.profile-and-.bashrc-conventions/
+[bash-demystified]: https://blog.dghubble.io/posts/.bashprofile-.profile-and-.bashrc-conventions/


### PR DESCRIPTION
Hi, I noticed that the link to the above blog post is currently broken. This PR updates the link to the new URL. 🙂