### PR TITLE
add that the ls command is short for listing

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -120,7 +120,7 @@ Typically, when you open a new command prompt you will be in
 your home directory to start.
 
 Now let's learn the command that will let us see the contents of our
-own filesystem.  We can see what's in our home directory by running `ls`:
+own filesystem.  We can see what's in our home directory by running `ls` (which stands for 'listing'):
 
 ~~~
 $ ls


### PR DESCRIPTION
I think it's very useful to spell out the shell commands for the learners to remember them more easily. In this episode it's already done for `pwd` but is missing for `ls`, so I added it in a similar way. 
---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
