### PR TITLE
change luck-based explanation to software-based

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -401,8 +401,8 @@ $ man ls
 {: .language-bash}
 
 This will turn your terminal into a page with a description
-of the `ls` command and its options and, if you're lucky, some examples
-of how to use it.
+of the `ls` command and its options and, depending on your version of
+`ls` and its documentation, some examples of how to use it.
 
 To navigate through the `man` pages,
 you may use <kbd>↑</kbd> and <kbd>↓</kbd> to move line-by-line,

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -401,8 +401,9 @@ $ man ls
 {: .language-bash}
 
 This will turn your terminal into a page with a description
-of the `ls` command and its options and, depending on your version of
-`ls` and its documentation, some examples of how to use it.
+of the `ls` command and its options and, depending on your variant of the
+terminal software, or your operating system, supplying `ls` and its
+documentation, some examples of how to use it.
 
 To navigate through the `man` pages,
 you may use <kbd>↑</kbd> and <kbd>↓</kbd> to move line-by-line,

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -401,9 +401,7 @@ $ man ls
 {: .language-bash}
 
 This will turn your terminal into a page with a description
-of the `ls` command and its options and, depending on your variant of the
-terminal software, or your operating system, supplying `ls` and its
-documentation, some examples of how to use it.
+of the `ls` command and its options.
 
 To navigate through the `man` pages,
 you may use <kbd>↑</kbd> and <kbd>↓</kbd> to move line-by-line,


### PR DESCRIPTION
The "if you're lucky" text in [Navigating Files and Directories](http://swcarpentry.github.io/shell-novice/02-filedir/index.html) doesn't offer a fact-based explanation for cases when `man ls` doesn't provide usage examples.

> This will turn your terminal into a page with a description of
> the `ls` command and its options and, if you’re lucky, some
> examples of how to use it.

If the `man` page for `ls` on a learner's device doesn't include usage examples they aren't unlucky, they've found a `man` page entry that lacks any examples.

Some possible replacements for "if you're lucky" are

* "depending on your version of `ls` and its documentation",
* "depending on your operating system,"
* "depending on the computer," and
* "depending on your system."