### PR TITLE
Update 03-create.md

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -75,6 +75,29 @@ creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg  solar.
 ~~~
 {: .output}
 
+Note that `mkdir` is not limited to creating single directories one at a time. The `-p` option flag allows `mkdir` to create a directory with any number of nested subdirectories in a single operation: 
+
+~~~
+$ mkdir -p thesis/chapter_1/section_1/subsection_1
+~~~
+{: .language-bash}
+
+The `ls` command has an option flag `-R` that will list all nested subdirectories wtihin a directory.  Let's use `ls -FR` to recursively list the new directory hierarchy we just created beneath the `thesis` directory:
+
+~~~
+$ ls -FR thesis
+chapter_1/
+
+thesis/chapter_1:
+section_1/
+
+thesis/chapter_1/section_1:
+subsection_1/
+
+thesis/chapter_1/section_1/subsection_1:
+~~~
+{: .language-bash}
+
 > ## Two ways of doing the same thing
 > Using the shell to create a directory is no different than using a file explorer.
 > If you open the current directory using your operating system's graphical file explorer,
@@ -851,6 +874,11 @@ Oftentimes one needs to copy or move several files at once. This can be done by 
 > ~~~
 > {: .language-bash}
 > ~~~
+> $ mkdir -p 2016-05-20/data/raw
+> $ mkdir -p 2016-05-20/data/processed
+> ~~~
+> {: .language-bash}
+> ~~~
 > $ mkdir 2016-05-20
 > $ cd 2016-05-20
 > $ mkdir data
@@ -863,8 +891,11 @@ Oftentimes one needs to copy or move several files at once. This can be done by 
 > > The first set uses relative paths to create the top level directory before
 > > the subdirectories.
 > >
-> > The third set of commands will give an error because `mkdir` won't create a subdirectory
+> > The third set of commands will give an error because the default behavior of `mkdir` won't create a subdirectory
 > > of a non-existant directory: the intermediate level folders must be created first.
+> >
+> > The fourth set of commands achieve this objective. Remember, the `-p` option flag, followed by a path of one or more 
+> > directories, will cause `mkdir` to create any intermediate subdirectories as required.
 > >
 > > The final set of commands generates the 'raw' and 'processed' directories at the same level
 > > as the 'data' directory.

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -75,14 +75,14 @@ creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg  solar.
 ~~~
 {: .output}
 
-Note that `mkdir` is not limited to creating single directories one at a time. The `-p` option flag allows `mkdir` to create a directory with any number of nested subdirectories in a single operation: 
+Note that `mkdir` is not limited to creating single directories one at a time. The `-p` option allows `mkdir` to create a directory with any number of nested subdirectories in a single operation: 
 
 ~~~
 $ mkdir -p thesis/chapter_1/section_1/subsection_1
 ~~~
 {: .language-bash}
 
-The `ls` command has an option flag `-R` that will list all nested subdirectories wtihin a directory.  Let's use `ls -FR` to recursively list the new directory hierarchy we just created beneath the `thesis` directory:
+The `-R` option to the `ls` command will list all nested subdirectories wtihin a directory.  Let's use `ls -FR` to recursively list the new directory hierarchy we just created beneath the `thesis` directory:
 
 ~~~
 $ ls -FR thesis
@@ -894,7 +894,7 @@ Oftentimes one needs to copy or move several files at once. This can be done by 
 > > The third set of commands will give an error because the default behavior of `mkdir` won't create a subdirectory
 > > of a non-existant directory: the intermediate level folders must be created first.
 > >
-> > The fourth set of commands achieve this objective. Remember, the `-p` option flag, followed by a path of one or more 
+> > The fourth set of commands achieve this objective. Remember, the `-p` option, followed by a path of one or more 
 > > directories, will cause `mkdir` to create any intermediate subdirectories as required.
 > >
 > > The final set of commands generates the 'raw' and 'processed' directories at the same level


### PR DESCRIPTION
Added lines 77 - 99 to introduce mkdir -p, along with a sample, as well as the introduction of the -R flag to ls to recursively list the newly created directory hierarchy beneath the thesis directory.  Added lines 877 - 879 to introduce an exercise scenario to highlight mkdir -p.  Added "the default behavior of" to line 894 to avoid leaving students with the impression that mkdir cannot create subdirectories.  Added lines 897-899 to provide a solution explanation for the mkdir -p exercise scenario.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
