### PR TITLE
Remove duplicate 'keypoints' in yaml header

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -13,7 +13,6 @@ keypoints:
 - "Identify the actual command, options, and filenames in a command-line call."
 - "Explain the steps in the shell's read-run-print cycle."
 - "Demonstrate the use of tab completion and explain its advantages."
-keypoints:
 - "A shell is a program whose primary purpose is to read commands and run other programs."
 - "The shell's main advantages are its high action-to-keystroke ratio, its support for
 automating repetitive tasks, and its capacity to access networked machines."


### PR DESCRIPTION
The yaml header had a duplicate 'keypoints' label, which would make it invalid for strict yaml parsers. I've removed the duplicate label so that it's easier to parse the data.