### PR TITLE
remove custom permalinks from Extras pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,5 @@
 ---
 layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: "Discussion"
-permalink: /discuss/
 ---
 ## Alphabet Soup
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: "Instructor Notes"
-permalink: /guide/
 ---
 *   Why do we learn to use the shell?
     *   Allows users to automate repetitive tasks

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
-root: ..
 ---
 
 ## Summary of Basic Commands


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use `/guide/` for their Instructor Notes page and others use `/guide.html`. This PR removes the `permalink` field from YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, to make established lessons consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Keeping the paths to these files consistent will help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

If and when this PR is merged, I'll update the link on https://software-carpentry.org/lessons/ to the Instructor Notes page for this lesson to avoid a broken link there. If you know of anywhere else that would need updating to avoid a broken link, please let me know!