### PR TITLE
03-create: Check emptiness before creating subdir

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -75,6 +75,13 @@ creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg  solar.
 ~~~
 {: .output}
 
+Since we've just created the `thesis` directory, there's nothing in it yet:
+
+~~~
+$ ls -F thesis
+~~~
+{: .language-bash}
+
 Note that `mkdir` is not limited to creating single directories one at a time. The `-p` option allows `mkdir` to create a directory with any number of nested subdirectories in a single operation: 
 
 ~~~
@@ -133,13 +140,6 @@ thesis/chapter_1/section_1/subsection_1:
 > If you need to refer to names of files or directories that have spaces
 > or other special characters, you should surround the name in quotes (`""`).
 {: .callout}
-
-Since we've just created the `thesis` directory, there's nothing in it yet:
-
-~~~
-$ ls -F thesis
-~~~
-{: .language-bash}
 
 ### Create a text file
 Let's change our working directory to `thesis` using `cd`,


### PR DESCRIPTION
The `mkdir -p` example creates directories in `thesis/`.
It might be meant as a "what if?" section, rather than hands-on exercise, but if people follow it, `thesis/` won't be empty at this point.

I suggest moving the `ls -F` that checks if the dir is empty above this section.

There are further `ls thesis` commands in the file that don't list `chapter_1/`, but I think people can figure out what's going on.
The change will work even if the `mkdir -p` section is removed (a possibility I see mentioned in some past discussion).

---

It's just a suggestion; feel free to change/close the PR as you see fit :)

While I'm here: ♥ Thank you for making the materials available! I am translating and adapting them for [a Czech-language course about Linux basics](https://naucse.python.cz/2020/linux-admin/carpentry-unix/filedir/) – with attribution and thanks, of course – and I find them remarkably well written & thought out.
