### PR TITLE
Specify the current directory for `grep -r` example, prevent hang.

### DIFF
--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -208,7 +208,7 @@ If we use the `-r` (recursive) option,
 Let's search recursively for `Yesterday` in the `data-shell/writing` directory:
 
 ```
-grep -r Yesterday
+grep -r Yesterday .
 ```
 {: .language-bash}
 


### PR DESCRIPTION
`grep` reads from stdin if no directory is specified. Running `grep -r Yesterday` hangs with the message: `grep: warning: recursive search of stdin`. Specifying `.` fixes. 
Run on macOS 10.14.6 GNU Bash 3.2.57(1)


