### PR TITLE
man pager key shortcuts case

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -401,16 +401,16 @@ $ man ls
 {: .language-bash}
 
 This will turn your terminal into a page with a description
-of the `ls` command and its options.
+of the `ls` command and its options, shown automatically through a *pager* program, like `more` or `less`.
 
 To navigate through the `man` pages,
 you may use <kbd>↑</kbd> and <kbd>↓</kbd> to move line-by-line,
-or try <kbd>B</kbd> and <kbd>Spacebar</kbd> to skip up and down by a full page.
+or try <kbd>b</kbd> and <kbd>Spacebar</kbd> to skip up and down by a full page.
 To search for a character or word in the `man` pages,
 use <kbd>/</kbd> followed by the character or word you are searching for.
-Sometimes a search will result in multiple hits.  If so, you can move between hits using <kbd>N</kbd> (for moving forward) and <kbd>Shift</kbd>+<kbd>N</kbd> (for moving backward).
+Sometimes a search will result in multiple hits.  If so, you can move between hits using <kbd>n</kbd> (for moving forward) and <kbd>Shift</kbd>+<kbd>n</kbd> (for moving backward).
 
-To **quit** the `man` pages, press <kbd>Q</kbd>.
+To **quit** the `man` pages, press <kbd>q</kbd>.
 
 > ## Manual pages on the web
 >


### PR DESCRIPTION
Mention that the man command goes through a pager program, and change case of key shortcuts to avoid confusion
