### PR TITLE
Fix #1116: Updated explanation and clarified the usage of `ls` with filename or directory as arguments

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -346,9 +346,20 @@ $ ls thesis
 ~~~
 {: .language-bash}
 
-Further,
-`ls` with a filename or directory name as an argument only lists that file or directory.
-We can use this to see that `quotes.txt` is still in our current directory:
+Alternatively, we can confirm the file `quotes.txt` is no longer present in the `thesis` directory:
+
+~~~
+$ ls thesis/quotes.txt
+~~~
+{: .language-bash}
+
+```
+ls: cannot access 'thesis/quotes.txt': No such file or directory
+```
+{: .output}
+
+`ls` with a filename as an argument lists that file itself as the output if the file exists in the directory specified in the argument. Otherwise, an error similar as above is printed. 
+We can use this to see that `quotes.txt` has indeed moved to and present in our current directory:
 
 ~~~
 $ ls quotes.txt


### PR DESCRIPTION
Based on the suggestions made in the comments of #1116 , the steps to understand and verify the operation of moving a file between directories are updated to convey a better clarity in using `ls` with filenames or directories as arguments.  


