### PR TITLE
Add note to navigate to home directory

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -69,7 +69,7 @@ which is Nelle's **home directory**:
 {: .callout}
 >  
 > We will also assume that your `pwd` command returns your users home directory. 
-> If `pwd` returns something different you may need to navigate there using `cd ~` 
+> If `pwd` returns something different you may need to navigate there using `cd` 
 > or some commands in this lesson will not work as written. 
 > See [Exploring Other Directories](exploring-other-directories) for more details 
 > on the `cd` command.

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -67,6 +67,12 @@ which is Nelle's **home directory**:
 > In future examples, we've used Mac output as the default - Linux and Windows
 > output may differ slightly, but should be generally similar.
 {: .callout}
+>  
+> We will also assume that your `pwd` command returns your users home directory. 
+> If `pwd` returns something different you may need to navigate there using `cd ~` 
+> or some commands in this lesson will not work as written. 
+> See [Exploring Other Directories](exploring-other-directories) for more details 
+> on the `cd` command.
 
 To understand what a 'home directory' is,
 let's have a look at how the file system as a whole is organized.  For the
@@ -478,6 +484,10 @@ $ ls -F Desktop
 data-shell/
 ~~~
 {: .output}
+
+Note that if a directory named `Desktop` does not exist in your current working directory
+this command will return an error. Typically a `Desktop` directory exists in your 
+home directory, which we assume is the current working directory of your bash shell.
 
 Your output should be a list of all the files and sub-directories in your
 Desktop directory, including the `data-shell` directory you downloaded at


### PR DESCRIPTION
I've had a learner whose shell's don't default to their home directory. We didn't catch this until `ls -F Desktop`, so I think they missed some of the material, or didn't grasp some of the details/useage of relative paths. 

I think it would be useful to mention explicitly that learners should navigate to their home directory if `pwd` returns something other than their home directory, both in "Home Directory Variation" and prior to the `ls -F Desktop` bash code chunk.

