### PR TITLE
Resolves issue #1125 (adds subheadings to Pipes and Filters)

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -11,11 +11,11 @@ objectives:
 - "Explain what usually happens if a program or pipeline isn't given any input to process."
 - "Explain Unix's 'small pieces, loosely joined' philosophy."
 keypoints:
+- "`wc` counts lines, words, and characters in its inputs."
 - "`cat` displays the contents of its inputs."
+- "`sort` sorts its inputs."
 - "`head` displays the first 10 lines of its input."
 - "`tail` displays the last 10 lines of its input."
-- "`sort` sorts its inputs."
-- "`wc` counts lines, words, and characters in its inputs."
 - "`command > [file]` redirects a command's output to a file (overwriting any existing content)."
 - "`command >> [file]` appends a command's output to a file."
 - "`[first] | [second]` is a pipeline: the output of the first command is used as the input to the second."
@@ -248,6 +248,8 @@ $ sort -n lengths.txt
 ~~~
 {: .output}
 
+
+## Capturing output from commands
 We can put the sorted list of lines in another temporary file called `sorted-lengths.txt`
 by putting `> sorted-lengths.txt` after the command,
 just as we used `> lengths.txt` to put the output of `wc` into `lengths.txt`.
@@ -357,6 +359,8 @@ the output of `head` must be the file with the fewest lines.
 > {: .solution}
 {: .challenge}
 
+
+## Passing output to another command
 If you think this is confusing,
 you're in good company:
 even once you understand what `wc`, `sort`, and `head` do,
@@ -378,6 +382,8 @@ It tells the shell that we want to use
 the output of the command on the left
 as the input to the command on the right.
 
+
+## Combining multiple commands
 Nothing prevents us from chaining pipes consecutively.
 That is, we can for example send the output of `wc` directly to `sort`,
 and then the resulting output to `head`.
@@ -446,6 +452,7 @@ the "sort" command is the input to the "head" command and the output of the
 {: .challenge}
 
 
+## Filtering output
 This idea of linking programs together is why Unix has been so successful.
 Instead of creating enormous programs that try to do many different things,
 Unix programmers focus on creating lots of simple tools that each do one job well,


### PR DESCRIPTION
This commit resolves issue #1125 ("Ep. 4 Pipes and Filters suggestion: 
Add subheadings") by changing the following:

1. Reorders the commands in the `keypoints` section to be in the same
   order as they are introduced in the lesson.
2. Adds the subheading "Capturing output from commands" (Line 252).
3. Adds the subheading "Passing output to another command" (Line 363).
4. Adds the subheading "Combining multiple commands" (Line 386).
5. Adds the subheading "Filtering output" (Line 455).

Note that the exact position of these subheadings could potentially be
adjusted slightly--these are just my intuition about where they would
naturally go.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
