### PR TITLE
Remove mentions of orthogonality

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -516,19 +516,6 @@ equivalent to `ls -Fa`.
 > is used.
 {: .callout}
 
-> ## Orthogonality
->
-> The special names `.` and `..` don't belong to `cd`;
-> they are interpreted the same way by every program.
-> For example,
-> if we are in `/Users/nelle/data`,
-> the command `ls ..` will give us a listing of `/Users/nelle`.
-> When the meanings of the parts are the same no matter how they're combined,
-> programmers say they are **orthogonal**:
-> Orthogonal systems tend to be easier for people to learn
-> because there are fewer special cases and exceptions to keep track of.
-{: .callout}
-
 These three commands are the basic commands for navigating the filesystem on your computer:
 `pwd`, `ls`, and `cd`. Let's explore some variations on those commands. What happens
 if you type `cd` on its own, without giving

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -686,7 +686,7 @@ Oftentimes one needs to copy or move several files at once. This can be done by 
 > However, generally commands like `wc` and `ls` see the lists of
 > file names matching these expressions, but not the wildcards
 > themselves. It is the shell, not the other programs, that deals with
-> expanding wildcards, and this is another example of orthogonal design.
+> expanding wildcards.
 {: .callout}
 
 > ## List filenames matching a pattern

--- a/reference.md
+++ b/reference.md
@@ -115,11 +115,6 @@ operating system
 :   Software that manages interactions between users, hardware, and software [processes](#process). Common
     examples are Linux, macOS, and Windows.
 
-orthogonal
-:   To have meanings or behaviors that are independent of each other.
-    If a set of concepts or tools are orthogonal,
-    they can be combined in any way.
-
 parameter
 :   A variable named in a function's declaration that is used to hold a value passed into the call.
     The term is often used interchangeably (and inconsistently) with [argument](#argument).


### PR DESCRIPTION
This PR closes #541 by removing mentions of "orthogonal design" in the lesson. The reasons for removing are:

- "orthogonal design" as an idea is not fleshed out
- Recognizing and giving names to software design patterns is beyond the scope of this lesson
- There is question about whether the examples are even _good_ examples of "orthogonal design" cf. #541 

(Edit: sorry, just now realizing I should have probably done this from a fork.)