### PR TITLE
Add filename output to clarify first loop example

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -60,14 +60,18 @@ and we can apply this to our example like this:
 ```
 $ for filename in basilisk.dat minotaur.dat unicorn.dat
 > do
+>     echo $filename
 >     head -n 2 $filename | tail -n 1
 > done
 ```
 {: .language-bash}
 
 ```
+basilisk.dat
 CLASSIFICATION: basiliscus vulgaris
+minotaur.dat
 CLASSIFICATION: bos hominus
+unicorn.dat
 CLASSIFICATION: equus monoceros
 ```
 {: .output}


### PR DESCRIPTION
Added "echo $filename" within initial loop example to make it easier to visualize in the output exactly where each line of output is coming from. While this adds a little complexity, it reduces potential for confusion.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
