### PR TITLE
Improve formatting, update paths/output for latest data

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -753,7 +753,8 @@ For example, `ls -s` will display the size of files and directories alongside th
 while `ls -S` will sort the files and directories by size, as shown below:
 
 ~~~
-$ ls -s Desktop/shell-lesson-data/data
+$ cd ~/Desktop/shell-lesson-data
+$ ls -s data
 ~~~
 {: .language-bash}
 ~~~
@@ -763,7 +764,7 @@ total 116
 ~~~
 {: .output}
 ~~~
-$ ls -S Desktop/shell-lesson-data/data
+$ ls -S data
 ~~~
 {: .language-bash}
 ~~~

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -754,10 +754,19 @@ while `ls -S` will sort the files and directories by size, as shown below:
 
 ~~~
 $ ls -s Desktop/shell-lesson-data/data
+~~~
+{: .language-bash}
+~~~
 total 116
  4 amino-acids.txt   4 animals.txt   4 morse.txt  12 planets.txt  76 sunspot.txt
  4 animal-counts     4 elements      4 pdb         4 salmon.txt
+~~~
+{: .output}
+~~~
 $ ls -S Desktop/shell-lesson-data/data
+~~~
+{: .language-bash}
+~~~
 sunspot.txt  animal-counts  pdb        amino-acids.txt  salmon.txt
 planets.txt  elements       morse.txt  animals.txt
 ~~~

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -376,8 +376,9 @@ $ ls -F Desktop/shell-lesson-data
 {: .language-bash}
 
 ~~~
-creatures/          molecules/          notes.txt           solar.pdf
-data/               north-pacific-gyre/ pizza.cfg           writing/
+creatures/  molecules/           notes.txt    pizza.cfg  writing/
+data/       north-pacific-gyre/  numbers.txt  solar.pdf
+
 ~~~
 {: .output}
 
@@ -429,8 +430,8 @@ $ ls -F
 {: .language-bash}
 
 ~~~
-amino-acids.txt   elements/     pdb/	        salmon.txt
-animals.txt       morse.txt     planets.txt     sunspot.txt
+amino-acids.txt  animals.txt  morse.txt  planets.txt  sunspot.txt
+animal-counts/   elements/    pdb/       salmon.txt
 ~~~
 {: .output}
 
@@ -489,8 +490,8 @@ $ ls -F -a
 {: .language-bash}
 
 ~~~
-./   .bash_profile  data/       north-pacific-gyre/  pizza.cfg  thesis/
-../  creatures/     molecules/  notes.txt            solar.pdf  writing/
+./   .bash_profile  data/       north-pacific-gyre/  numbers.txt  solar.pdf
+../  creatures/     molecules/  notes.txt            pizza.cfg    writing/
 ~~~
 {: .output}
 
@@ -752,11 +753,11 @@ For example, `ls -s` will display the size of files and directories alongside th
 while `ls -S` will sort the files and directories by size, as shown below:
 
 ~~~
-$ ls -s Desktop/shell-lesson-data/data
+$ ls -s ~/Desktop/shell-lesson-data/data
 total 116
  4 amino-acids.txt   4 animals.txt   4 morse.txt  12 planets.txt  76 sunspot.txt
  4 animal-counts     4 elements      4 pdb         4 salmon.txt
-$ ls -S Desktop/shell-lesson-data/data
+$ ls -S ~/Desktop/shell-lesson-data/data
 sunspot.txt  animal-counts  pdb        amino-acids.txt  salmon.txt
 planets.txt  elements       morse.txt  animals.txt
 ~~~

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -753,11 +753,11 @@ For example, `ls -s` will display the size of files and directories alongside th
 while `ls -S` will sort the files and directories by size, as shown below:
 
 ~~~
-$ ls -s ~/Desktop/shell-lesson-data/data
+$ ls -s Desktop/shell-lesson-data/data
 total 116
  4 amino-acids.txt   4 animals.txt   4 morse.txt  12 planets.txt  76 sunspot.txt
  4 animal-counts     4 elements      4 pdb         4 salmon.txt
-$ ls -S ~/Desktop/shell-lesson-data/data
+$ ls -S Desktop/shell-lesson-data/data
 sunspot.txt  animal-counts  pdb        amino-acids.txt  salmon.txt
 planets.txt  elements       morse.txt  animals.txt
 ~~~

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -886,10 +886,10 @@ or specifying a naming pattern using wildcards.
 > You're starting a new experiment and would like to duplicate the directory
 > structure from your previous experiment so you can add new data.
 >
-> Assume that the previous experiment is in a folder called '2016-05-18',
+> Assume that the previous experiment is in a folder called `2016-05-18`,
 > which contains a `data` folder that in turn contains folders named `raw` and
 > `processed` that contain data files.  The goal is to copy the folder structure
-> of the `2016-05-18-data` folder into a folder called `2016-05-20`
+> of the `2016-05-18` folder into a folder called `2016-05-20`
 > so that your final directory structure looks like this:
 >
 > ~~~

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -45,7 +45,8 @@ $ ls -F
 {: .language-bash}
 
 ~~~
-creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg  solar.pdf  writing/
+creatures/  molecules/           notes.txt    pizza.cfg  writing/
+data/       north-pacific-gyre/  numbers.txt  solar.pdf
 ~~~
 {: .output}
 
@@ -71,8 +72,8 @@ $ ls -F
 {: .language-bash}
 
 ~~~
-creatures/  data/  molecules/  north-pacific-gyre/  notes.txt  pizza.cfg
-solar.pdf  thesis/  writing/
+creatures/  molecules/           notes.txt    pizza.cfg  thesis/
+data/       north-pacific-gyre/  numbers.txt  solar.pdf  writing/
 ~~~
 {: .output}
 
@@ -647,8 +648,8 @@ or specifying a naming pattern using wildcards.
 > ~~~
 > {: .language-bash}
 > ~~~
-> amino-acids.txt  animals.txt  backup/  elements/  morse.txt  pdb/
-> planets.txt  salmon.txt  sunspot.txt
+> amino-acids.txt  animals.txt  elements/  pdb/         salmon.txt
+> animal-counts/   backup/      morse.txt  planets.txt  sunspot.txt
 > ~~~
 > {: .output}
 > ~~~

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -295,7 +295,7 @@ draft.txt
 Returning to the `shell-lesson-data` directory,
 
 ```
-cd ~/Desktop/shell-lesson-data/
+$ cd ~/Desktop/shell-lesson-data/
 ```
 {: .language-bash}
 
@@ -341,7 +341,7 @@ to tell `mv` that we want to keep the filename
 but put the file somewhere new.
 (This is why the command is called 'move'.)
 In this case,
-the directory name we use is the special directory name`.` that we mentioned earlier.
+the directory name we use is the special directory name `.` that we mentioned earlier.
 
 ~~~
 $ mv thesis/quotes.txt .
@@ -372,7 +372,7 @@ $ ls thesis/quotes.txt
 ```
 ls: cannot access 'thesis/quotes.txt': No such file or directory
 ```
-{: .output}
+{: .error}
 
 `ls` with a filename or directory as an argument only lists the requested file or directory.
 If the file given as the argument doesn't exist, the shell returns an error as we saw above.
@@ -563,7 +563,7 @@ $ ls quotes.txt
 ```
 ls: cannot access 'quotes.txt': No such file or directory
 ```
-{: .output}
+{: .error}
 
 > ## Deleting Is Forever
 >
@@ -584,9 +584,9 @@ ls: cannot access 'quotes.txt': No such file or directory
 >
 > > ## Solution
 > > ```
-> > $ rm: remove regular file 'thesis_backup/quotations.txt'? y
+> > rm: remove regular file 'thesis_backup/quotations.txt'? y
 > > ```
-> > {: .language-bash}
+> > {: .output}
 > > The `-i` option will prompt before (every) removal (use <kbd>Y</kbd> to confirm deletion
 > > or <kbd>N</kbd> to keep the file).
 > > The Unix shell doesn't have a trash bin, so all the files removed will disappear forever.
@@ -666,9 +666,9 @@ or specifying a naming pattern using wildcards.
 > > because it is expecting a directory name as the last argument.
 > >
 > > ```
-> > cp: target ‘morse.txt’ is not a directory
+> > cp: target 'morse.txt' is not a directory
 > > ```
-> > {: .output}
+> > {: .error}
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -36,8 +36,8 @@ $ ls molecules
 {: .language-bash}
 
 ~~~
-cubane.pdb    ethane.pdb    methane.pdb
-octane.pdb    pentane.pdb   propane.pdb
+cubane.pdb    methane.pdb    pentane.pdb
+ethane.pdb    octane.pdb     propane.pdb
 ~~~
 {: .output}
 

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -219,7 +219,7 @@ or a subset of data.
 > ~~~
 > $ for datafile in *.pdb
 > > do
-> >	ls $datafile
+> >     ls $datafile
 > > done
 > ~~~
 > {: .language-bash}

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -453,7 +453,7 @@ from whatever file is being processed
 > head: cannot open ‘red dragon.dat’ for reading: No such file or directory
 > head: cannot open ‘purple unicorn.dat’ for reading: No such file or directory
 > ~~~
-> {: .output}
+> {: .error}
 >
 > Try removing the quotes around `$filename` in the loop above to see the effect of the quote
 > marks on spaces. Note that we get a result from the loop command for unicorn.dat

--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -509,16 +509,16 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > with that extension. For example:
 >
 > ~~~
-> $ bash longest.sh shell-lesson-data/exercise-data/proteins pdb
+> $ bash longest.sh shell-lesson-data/data/pdb pdb
 > ~~~
 > {: .language-bash}
 >
-> would print the name of the `.pdb` file in `shell-lesson-data/exercise-data/proteins` that has
+> would print the name of the `.pdb` file in `shell-lesson-data/data/pdb` that has
 > the most lines.
 >
 > Feel free to test your script on another directory e.g.
 > ~~~
-> $ bash longest.sh shell-lesson-data/exercise-data/writing txt
+> $ bash longest.sh shell-lesson-data/writing/data txt
 > ~~~
 > {: .language-bash}
 >

--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -323,9 +323,9 @@ $ bash sorted.sh *.pdb ../creatures/*.dat
 > > # Loop over all files
 > > for file in $@
 > > do
-> > 	echo "Unique species in $file:"
-> > 	# Extract species names
-> > 	cut -d , -f 2 $file | sort | uniq
+> >     echo "Unique species in $file:"
+> >     # Extract species names
+> >     cut -d , -f 2 $file | sort | uniq
 > > done
 > > ```
 > > {: .language-bash}

--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -50,7 +50,7 @@ We can use the text editor to directly edit the file -- we'll simply insert the 
 ~~~
 head -n 15 octane.pdb | tail -n 5
 ~~~
-{: .language-bash}
+{: .source}
 
 This is a variation on the pipe we constructed earlier:
 it selects lines 11-15 of the file `octane.pdb`.
@@ -111,7 +111,7 @@ Now, within "nano", replace the text `octane.pdb` with the special variable call
 ~~~
 head -n 15 "$1" | tail -n 5
 ~~~
-{: .output}
+{: .source}
 
 Inside a shell script,
 `$1` means 'the first filename (or other argument) on the command line'.
@@ -172,7 +172,7 @@ $ nano middle.sh
 ~~~
 head -n "$2" "$1" | tail -n "$3"
 ~~~
-{: .output}
+{: .source}
 
 We can now run:
 
@@ -221,7 +221,7 @@ $ nano middle.sh
 # Usage: bash middle.sh filename end_line num_lines
 head -n "$2" "$1" | tail -n "$3"
 ~~~
-{: .output}
+{: .source}
 
 A comment starts with a `#` character and runs to the end of the line.
 The computer ignores comments,
@@ -266,7 +266,7 @@ $ nano sorted.sh
 # Usage: bash sorted.sh one_or_more_filenames
 wc -l "$@" | sort -n
 ~~~
-{: .output}
+{: .source}
 
 ~~~
 $ bash sorted.sh *.pdb ../creatures/*.dat
@@ -472,7 +472,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > While you are in the `molecules` directory, you type the following command:
 >
 > ~~~
-> bash script.sh '*.pdb' 1 1
+> $ bash script.sh '*.pdb' 1 1
 > ~~~
 > {: .language-bash}
 >
@@ -623,7 +623,7 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > To figure out why, re-run the script using the `-x` option:
 >
 > ~~~
-> bash -x do-errors.sh NENE*A.txt NENE*B.txt
+> $ bash -x do-errors.sh NENE*A.txt NENE*B.txt
 > ~~~
 > {: .language-bash}
 >

--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -393,8 +393,8 @@ Miscellaneous:
 > > ```
 > > for sis in Jo Meg Beth Amy
 > > do
-> > 	echo $sis:
-> >	grep -ow $sis LittleWomen.txt | wc -l
+> >     echo $sis:
+> >     grep -ow $sis LittleWomen.txt | wc -l
 > > done
 > > ```
 > > {: .source}
@@ -403,8 +403,8 @@ Miscellaneous:
 > > ```
 > > for sis in Jo Meg Beth Amy
 > > do
-> > 	echo $sis:
-> >	grep -ocw $sis LittleWomen.txt
+> >     echo $sis:
+> >     grep -ocw $sis LittleWomen.txt
 > > done
 > > ```
 > > {: .source}


### PR DESCRIPTION
This PR contains formatting fixes and improvements, and updates content to account for changes in the `shell-lesson-data` directory. I have tried to avoid any controversial changes. The specific things changed here are as follows:

- The paths given in the challenge "Find the Longest File With a Given Extension" in Episode 6 were out of date and have been updated.
- The outputs of `ls` have been updated to match what a learner would see after doing everything in order from a fresh copy of `shell-lesson-data`. The one exception is that I have ignored the `touch my_file.txt` command in Episode 3: that's a tricky one.
- In certain cases, it looked like one-line `ls` output had been manually split over two lines (entries ordered across then down); I have changed these cases to proper two-line `ls` output, that is, ordered down then across.
- I have added `$ ` at the start of a few lines that were meant to be run at the prompt, and removed it from an output line.
- I have cleaned the indentation of `for` loops so they all use four spaces as standard, as some tabs had crept in.
- Where an output block contained only errors, I have changed the format directive to `{ .error}`.
- Where bash script lines had been formatted as `{ .output}`, I have changed the directive to `{ .source}`. There is one case where I have changed `{ .language-bash}` to `{ .source}` (at the start of Episode 6, to match the examples that follow immediately after) but otherwise I have left those alone.
- I corrected some typos in "Reproduce a folder structure" in Episode 3 and added a missing space a bit further up (under "Moving files and directories").

Sorry for bundling all these changes up, but it seemed more efficient than submitting each change separately.