### PR TITLE
02-filedir.md: change order of key points

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -16,15 +16,15 @@ keypoints:
 - "The file system is responsible for managing information on the disk."
 - "Information is stored in files, which are stored in directories (folders)."
 - "Directories can also store other directories, which then form a directory tree."
-- "`cd [path]` changes the current working directory."
-- "`ls [path]` prints a listing of a specific file or directory; `ls` on its own lists the current working directory."
 - "`pwd` prints the user's current working directory."
-- "`/` on its own is the root directory of the whole file system."
-- "Most commands take options that begin with a `-`."
-- "A relative path specifies a location starting from the current location."
-- "An absolute path specifies a location from the root of the file system."
+- "`ls [path]` prints a listing of a specific file or directory; `ls` on its own lists the current working directory."
+- "`cd [path]` changes the current working directory."
+- "Most commands take options that begin with a single `-`."
 - "Directory names in a path are separated with `/` on Unix, but `\\` on Windows."
-- "`..` means 'the directory above the current one'; `.` on its own means 'the current directory'."
+- "`/` on its own is the root directory of the whole file system."
+- "An absolute path specifies a location from the root of the file system."
+- "A relative path specifies a location starting from the current location."
+- "`.` on its own means 'the current directory'; `..` means 'the directory above the current one'."
 ---
 
 The part of the operating system responsible for managing files and directories


### PR DESCRIPTION
The proposed order implies three consistent blocks of information that are didactically more meaningful. Hopefully the new arrangement makes it easier for the novice to memorize the prescriptions and commands by recalling their navigation experience as it unfolds.
Firstly, all objects are introduced (filesystem, files, directories, directory, trees); no change.
Secondly, all commands are sorted from where you are now to where you can go, plus a closing note on command options.
Thirdly, all information on paths is shown (their syntax, the root path, then the absolute paths, then the relative ones, then the shorthand for the current directory, and that for the directory above).
It might still be discussed whether the correct block order is 1-3-2.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
