### PR TITLE
01-intro.md: clarification about the Git Bash name

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -49,6 +49,9 @@ The most popular Unix shell is Bash (the Bourne Again SHell ---
 so-called because it's derived from a shell written by Stephen Bourne).
 Bash is the default shell on most modern implementations of Unix and in most packages that provide
 Unix-like tools for Windows.
+To avoid that the name 'Git Bash' results in confusion during the Software Carpentries, 
+recall that Bash is a much older piece of software than Git; Git makes it only possible to use the Unix-based shell Bash inside Windows. 
+So, Bash is a flavor of the command shell, and Git Bash is no special flavor of Bash.
 
 Using the shell will take some effort and some time to learn.
 While a GUI presents you with choices to select, CLI choices are not automatically presented to you,


### PR DESCRIPTION
A novice approaching both Bash and Git during the Software Carpentries may think that the name 'Git Bash' means that Bash is a feature or a flavour of Git.
A comment at the point in which Windows users install the Git-based Bash emulator clarifies the relationship between these two pieces of software.
An actual question during a Software Carpentries session stimulated this edit.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
