### PR TITLE
Update 07-find.md

### DIFF
--- a/_episodes/07-find.md
+++ b/_episodes/07-find.md
@@ -472,7 +472,7 @@ which is where we want our search to start.
 under the current working directory.
 This can seem useless at first but `find` has many options
 to filter the output and in this lesson we will discover some
-of them.
+of them. In Linux, `find` by default searches within the current directory.  
 
 The first option in our list is
 `-type d` that means 'things that are directories'.


### PR DESCRIPTION
Today, while teaching at SWC workshop, I had a question from the user about the need for '.' after the find command. Apparently in the linux terminal, I can just type find and it by default searches only within the current directory. No '.' was required.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
