### PR TITLE
Remove note on WSL for Windows

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -60,14 +60,6 @@ which gives you access to both Bash shell commands and Git.
 
 Once installed, you can open a terminal by running the program Git Bash from the Windows start
 menu.
-
-**For advanced users:**
-
-As an alternative to Git for Windows you may wish to [Install the Windows Subsystem for Linux][wsl]
-which gives access to a Bash shell command-line tool in Windows 10.
-
-Please note that commands in the Windows Subsystem for Linux (WSL) may differ slightly
-from those shown in the lesson or presented in the workshop.
 </article>
 
 <article role="tabpanel" class="tab-pane" id="macos">


### PR DESCRIPTION
Grace Fishbein and I were helping out at a Unix Shell workshop today, and the students using WSL bash were having a very hard time following along. Here are a number of incompatibilities that we noticed:

- The desktop directory is completely different
- Tab completion didn't work for everyone
- `nano` is not available
- `man` is not available

I would like to remove the note about using WSL as an alternative, in order to avoid such incompatibilities during lessons. By the virtue of the lesson, we cannot assume that they are the "advanced user" that the note assumes.