### PR TITLE
Extra prompt on line 663

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -660,7 +660,7 @@ or specifying a naming pattern using wildcards.
 > ~~~
 > {: .output}
 > ~~~
-> $ $ cp minotaur.dat unicorn.dat basilisk.dat
+> $ cp minotaur.dat unicorn.dat basilisk.dat
 > ~~~
 > {: .language-bash}
 >


### PR DESCRIPTION
Line 663 original 

`> $ $ cp minotaur.dat unicorn.dat basilisk.dat`
 
Updated line 663 

`> $ cp minotaur.dat unicorn.dat basilisk.dat` 

TL'DR
Removed extra prompt (second $ before copy command)
