### PR TITLE
Ep. 02: comment on block sizes for 'ls -s'

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -761,8 +761,9 @@ total 28
 ~~~
 {: .output}
 
-Note that the sizes returned by `ls -s` are in *blocks*. As these are defined differently for different operating systems, you may
-not obtain the same figures as in the example.
+Note that the sizes returned by `ls -s` are in *blocks*. 
+As these are defined differently for different operating systems,
+you may not obtain the same figures as in the example.
 
 ~~~
 $ ls -S exercise-data

--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -761,6 +761,9 @@ total 28
 ~~~
 {: .output}
 
+Note that the sizes returned by `ls -s` are in *blocks*. As these are defined differently for different operating systems, you may
+not obtain the same figures as in the example.
+
 ~~~
 $ ls -S exercise-data
 ~~~


### PR DESCRIPTION
'ls -s' returns different block sizes depending on the OS. 
The issue was already raised in #1302, but I have also observed it on Windows, where the output (at least on my system) is:
```
total 1 

0 animal-counts/  0 creatures/  1 numbers.txt  0 proteins/  0 writing/ 
```
This PR adds a short note mentioning this, and warning that people may not obtain the same figures as in the example.
