### PR TITLE
Corrected typo in 02-filedir.md that led to `No such file or directory`

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -843,7 +843,7 @@ Pressing <kbd>Tab</kbd> again does nothing,
 since there are multiple possibilities;
 pressing <kbd>Tab</kbd> twice brings up a list of all the files.
 
-If Nelle adds <kbd>G</kbd> and presses <kbd>Tab</kbd> again,
+If Nelle adds <kbd>g</kbd> to the directory `north-pacific-gyre/` and presses <kbd>Tab</kbd> again,
 the shell will append 'goo' since all files that start with 'g' share
 the first three characters 'goo'.
 


### PR DESCRIPTION
Corrected typo and clarified formulation of the lesson a bit. Before, output would show
`ls: north-pacific-gyre/G: No such file or directory`
