### PR TITLE
Fix directory names to match shell-lesson-data structure

### DIFF
--- a/_episodes/06-script.md
+++ b/_episodes/06-script.md
@@ -517,16 +517,16 @@ Of course, this introduces another tradeoff between flexibility and complexity.
 > with that extension. For example:
 >
 > ~~~
-> $ bash longest.sh shell-lesson-data/data/pdb pdb
+> $ bash longest.sh shell-lesson-data/exercise-data/proteins pdb
 > ~~~
 > {: .language-bash}
 >
-> would print the name of the `.pdb` file in `shell-lesson-data/data/pdb` that has
+> would print the name of the `.pdb` file in `shell-lesson-data/exercise-data/proteins` that has
 > the most lines.
 >
 > Feel free to test your script on another directory e.g.
 > ~~~
-> $ bash longest.sh shell-lesson-data/writing/data txt
+> $ bash longest.sh shell-lesson-data/exercise-data/writing txt
 > ~~~
 > {: .language-bash}
 >


### PR DESCRIPTION
The directory structure in one of the exercises in lesson 6 does not match the directory structure in the provided data. This should provide a fix to that.