### PR TITLE
Update 04-pipefilter.md

### DIFF
--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -24,8 +24,8 @@ keypoints:
 Now that we know a few basic commands,
 we can finally look at the shell's most powerful feature:
 the ease with which it lets us combine existing programs in new ways.
-We'll start with the directory `shell-lesson-data/exercise-data/proteins`
-that contains six files describing some simple organic molecules.
+We'll start in the directory `shell-lesson-data/exercise-data/`.
+In here, we find a directory called `proteins` that contains six files describing some simple organic molecules.
 The `.pdb` extension indicates that these files are in Protein Data Bank format,
 a simple text format that specifies the type and position of each atom in the molecule.
 

--- a/_episodes/04-pipefilter.md
+++ b/_episodes/04-pipefilter.md
@@ -25,7 +25,8 @@ Now that we know a few basic commands,
 we can finally look at the shell's most powerful feature:
 the ease with which it lets us combine existing programs in new ways.
 We'll start in the directory `shell-lesson-data/exercise-data/`.
-In here, we find a directory called `proteins` that contains six files describing some simple organic molecules.
+In here, we find a directory called `proteins` that contains six files
+describing some simple organic molecules.
 The `.pdb` extension indicates that these files are in Protein Data Bank format,
 a simple text format that specifies the type and position of each atom in the molecule.
 


### PR DESCRIPTION
Current wording implies we start in the "shell-lesson-data/exercise-data/proteins" directory, which is incorrect (and means you cannot 'ls' the content of the proteins directory). Edited language used when describing starting directory to make instructions more explicit. 


