### PR TITLE
01-intro.md: mention nontrivial prompts

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -92,6 +92,15 @@ typing will appear.
 The cursor is usually a flashing or solid block, but it can also be an underscore or a pipe.
 You may have seen it in a text editor program, for example.
 
+Note that your prompt might look a little different. In particular, most popular shell environments by default put your user name and the host name before the `$`. Such a prompt might look like, e.g.:
+
+~~~
+nelle@localhost $
+~~~
+{: .language-bash}
+
+The prompt might even include more than this. Do not worry if your prompt is not just a short `$ `. This lesson does not depend on this additional information and it should also not get in your way. The only important item to focus on is the `$ ` character itself and we will see later why.
+
 So let's try our first command, `ls` which is short for listing.
 This command will list the contents of the current directory:
 


### PR DESCRIPTION
A lot of standard environments set a prompt that is not just a dollar sign. However, only the latter is used in the lecture. This can create confusion for learners, as their environment most often does not look like the one of the lecturer. This commonly happens because user or host names are included in the prompt by default and those most often are different not only between lecturer and learner, but also between learners.

This commit adds a short paragraph that explains that what people see before the $-sign might be different and include things like their user name. It also gives a simple example, before it specifically mentiones that regardless of what is before that dollar sign: they should not worry. Finally, it again puts emphasis on the dollar sign itself as the only thing they should focus on, because this will be used later in the course. It leaves the details to those places, as this is too early to go into these things without creating even more confusion.

I expect this addition to add 1 more minute. However, this should in most cases (and especially for people really new to the shell) help in recovering from confusion later, and might in the end save time.
