### PR TITLE
Fix typo and history error

### DIFF
--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -630,7 +630,7 @@ $ for datafile in NENE*A.txt NENE*B.txt; do echo $datafile stats-$datafile; done
 ~~~
 {: .language-bash}
 
-Using the left arrow key,
+Using the up arrow key,
 Nelle backs up and changes the command `echo` to `bash goostats.sh`:
 
 ~~~
@@ -693,16 +693,16 @@ so she decides to get some coffee and catch up on her reading.
 > ~~~
 > {: .language-bash}
 > ~~~
->   456  ls -l NENE0*.txt
->   457  rm stats-NENE01729B.txt.txt
->   458  bash goostats.sh NENE01729B.txt stats-NENE01729B.txt
->   459  ls -l NENE0*.txt
->   460  history
+> 456  for datafile in NENE*A.txt NENE*B.txt; do   echo $datafile stats-$datafile; done
+> 457  for datafile in NENE*A.txt NENE*B.txt; do echo $datafile stats-$datafile; done
+> 458  for datafile in NENE*A.txt NENE*B.txt; do bash goostats.sh $datafile stats-$datafile; done
+> 459  for datafile in NENE*A.txt NENE*B.txt; do echo $datafile; bash goostats.sh $datafile stats-$datafile; done
+> 460  history | tail -n 5
 > ~~~
 > {: .output}
 >
-> then she can re-run `goostats.sh` on `NENE01729B.txt` simply by typing
-> `!458`.
+> then she can re-run `goostats.sh` on the files simply by typing
+> `!459`.
 {: .callout}
 
 > ## Other History Commands

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -630,8 +630,8 @@ $ for datafile in NENE*A.txt NENE*B.txt; do echo $datafile stats-$datafile; done
 ~~~
 {: .language-bash}
 
-Using the up arrow key,
-Nelle backs up and changes the command `echo` to `bash goostats.sh`:
+Using the <kbd>←</kbd>,
+Nelle navigates to and changes the command `echo` to `bash goostats.sh`:
 
 ~~~
 $ for datafile in NENE*A.txt NENE*B.txt; do bash goostats.sh $datafile stats-$datafile; done
@@ -696,7 +696,8 @@ so she decides to get some coffee and catch up on her reading.
 > 456  for datafile in NENE*A.txt NENE*B.txt; do   echo $datafile stats-$datafile; done
 > 457  for datafile in NENE*A.txt NENE*B.txt; do echo $datafile stats-$datafile; done
 > 458  for datafile in NENE*A.txt NENE*B.txt; do bash goostats.sh $datafile stats-$datafile; done
-> 459  for datafile in NENE*A.txt NENE*B.txt; do echo $datafile; bash goostats.sh $datafile stats-$datafile; done
+> 459  for datafile in NENE*A.txt NENE*B.txt; do echo $datafile; bash goostats.sh $datafile
+> stats-$datafile; done
 > 460  history | tail -n 5
 > ~~~
 > {: .output}

--- a/_episodes/05-loop.md
+++ b/_episodes/05-loop.md
@@ -631,7 +631,7 @@ $ for datafile in NENE*A.txt NENE*B.txt; do echo $datafile stats-$datafile; done
 {: .language-bash}
 
 Using the <kbd>←</kbd>,
-Nelle navigates to and changes the command `echo` to `bash goostats.sh`:
+Nelle navigates to the `echo` command and changes it to `bash goostats.sh`:
 
 ~~~
 $ for datafile in NENE*A.txt NENE*B.txt; do bash goostats.sh $datafile stats-$datafile; done


### PR DESCRIPTION
- use up instead of left arrow key to get previous command
- use history that is similar to what one would obtain based on following these instructions
