### PR TITLE
Remove old language indicator and join code fences

### DIFF
--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -42,13 +42,8 @@ $ pwd
 
 Next we'll move to the `exercise-data/writing` directory and see what it contains:
 
-```
-$ cd exercise-data/writing/
-```
-
-{:  .language-bash}
-
 ```bash
+$ cd exercise-data/writing/
 $ ls -F
 ```
 


### PR DESCRIPTION
There was one old-style language indicator for code highlight left by the port. This PR fixes that.

In addition I joined the two code fences, each containing only one command, which are supposed to be executed in sequence with the first not printing any output. I saw the same later in the episode (see for example in “Create a text file”).