### PR TITLE
Add `-n` switch to grep command

### DIFF
--- a/episodes/07-find.md
+++ b/episodes/07-find.md
@@ -331,7 +331,7 @@ sequence in one command in order to achieve Leah's goal:
 cut -d : -f 2
 >
 |
-grep -w $1 -r $2
+grep -w -n $1 -r $2
 |
 $1.txt
 cut -d , -f 1,3


### PR DESCRIPTION
Without the -n switch on grep to include line numbers on the result, the `cut -d : -f 2` of the script serves no purpose

