### PR TITLE
Fix directory structure leading to file not found error in Ep 6 - Scripts

### DIFF
--- a/episodes/06-script.md
+++ b/episodes/06-script.md
@@ -609,7 +609,7 @@ cubane.pdb ethane.pdb methane.pdb octane.pdb pentane.pdb propane.pdb.pdb
 ## Debugging Scripts
 
 Suppose you have saved the following script in a file called `do-errors.sh`
-in Nelle's `north-pacific-gyre/scripts` directory:
+in Nelle's `north-pacific-gyre` directory:
 
 ```bash
 # Calculate stats for data files.


### PR DESCRIPTION
Remove mention of /scripts directory, which does not exist

Fixes #1394 