### PR TITLE
changing quotes to single quotes

### DIFF
--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -146,7 +146,7 @@ There are special characters that can cause your command to not work as
 expected and can even result in data loss.
 
 If you need to refer to names of files or directories that have spaces
-or other special characters, you should surround the name in quotes (`""`).
+or other special characters, you should surround the name in single quotes (`''`).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -146,7 +146,8 @@ There are special characters that can cause your command to not work as
 expected and can even result in data loss.
 
 If you need to refer to names of files or directories that have spaces
-or other special characters, you should surround the name in single quotes (`''`).
+or other special characters, you should surround the name in single
+[quotes](https://www.gnu.org/software/bash/manual/html_node/Quoting.html) (`''`).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
When dealing with special characters the lesson advises to use quotes, however single quotes is the safer option. For example

```
touch \$HOME
ls "$HOME" # lists the contents of the home directory
ls '$HOME' # lists the '$HOME' file
```

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

---
