### PR TITLE
Example of omitting -r when using cp

### DIFF
--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -480,7 +480,7 @@ thesis_backup:
 quotations.txt
 ```
 
-It is important to include the `-r` flag if you want to copy a directory and you omit this option
+It is important to include the `-r` flag. If you want to copy a directory and you omit this option
 you will see a message that the directory has been omitted because `-r not specified`.
 
 ``` bash

--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -480,6 +480,15 @@ thesis_backup:
 quotations.txt
 ```
 
+It is important to include the `-r` flag if you want to copy a directory and you omit this option
+you will see a message that the directory has been omitted because `-r not specified`.
+
+``` bash
+$ cp thesis thesis_backup
+cp: -r not specified; omitting directory 'thesis'
+```
+
+
 :::::::::::::::::::::::::::::::::::::::  challenge
 
 ## Renaming Files
@@ -1027,5 +1036,3 @@ as the 'data' directory.
 - Depending on the type of work you do, you may need a more powerful text editor than Nano.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-
-


### PR DESCRIPTION
Closes #1258

Adds an explicit example of what happens when the `-r` flag is omitted when trying to use `cp` to copy a directory.

