### PR TITLE
updated path in 05-loop.md to be relative to home directory

### DIFF
--- a/episodes/05-loop.md
+++ b/episodes/05-loop.md
@@ -594,9 +594,10 @@ Since she's still learning how to use the shell,
 she decides to build up the required commands in stages.
 Her first step is to make sure that she can select the right input files --- remember,
 these are ones whose names end in 'A' or 'B', rather than 'Z'.
-Starting from her home directory, Nelle types:
+Moving to the `north-pacific-gyre` directory, Nelle types:
 
 ```bash
+$ cd
 $ cd Desktop/shell-lesson-data/north-pacific-gyre
 $ for datafile in NENE*A.txt NENE*B.txt
 > do

--- a/episodes/05-loop.md
+++ b/episodes/05-loop.md
@@ -597,7 +597,7 @@ these are ones whose names end in 'A' or 'B', rather than 'Z'.
 Starting from her home directory, Nelle types:
 
 ```bash
-$ cd north-pacific-gyre
+$ cd Desktop/shell-lesson-data/north-pacific-gyre
 $ for datafile in NENE*A.txt NENE*B.txt
 > do
 >     echo $datafile


### PR DESCRIPTION
Currently, in the "Nelle's Pipeline: Processing Files" section of [episodes/05-loop.md](https://github.com/swcarpentry/shell-novice/blob/61534b49425a60bbfd78cfab5427a27b6bf91a3c/episodes/05-loop.md?plain=1#L597C13-L597C13) (line 597), the text reads

> Starting from her home directory, Nelle types:

however, the [code snippet](https://github.com/swcarpentry/shell-novice/blob/61534b49425a60bbfd78cfab5427a27b6bf91a3c/episodes/05-loop.md?plain=1#L600) just below this (line 600) then reads:

```bash
cd north-pacific-gyre
```

This path is incorrect, as if starting from the users home directory this line should read

```bash
cd Desktop/shell-lesson-data/north-pacific-gyre
```
