### PR TITLE
Update remove-unneeded-files sol'n 4 in lesson 4 (issue #1415)

### DIFF
--- a/episodes/04-pipefilter.md
+++ b/episodes/04-pipefilter.md
@@ -729,8 +729,8 @@ and *only* the processed data files?
 3. The shell would expand `*` to match everything in the current directory,
   so the command would try to remove all matched files and an additional
   file called `.txt`
-4. The shell would expand `*.*` to match all files with any extension,
-  so this command would delete all files
+4. The shell expands `*.*` to match all filenames containing at least one
+  `.`, including the processed files (`.txt`) *and* raw files (`.dat`)
   
   
 


### PR DESCRIPTION
This PR is follows up issue #1415.

In the [removing-unneeded-files](https://swcarpentry.github.io/shell-novice/04-pipefilter.html#removing-unneeded-files) question of lesson 4, the description of the 4th solution

``` md
The shell would expand `*.*` to match all files with any extension, so this command would delete all files
```

has been replaced with 

``` md
The shell expands `*.*` to match all filenames containing at least one `.`, including the processed files (`.txt`) *and* raw files (`.dat`)
```

Note that the replacement text is slightly different from that suggested in #1415. I can easily use that text if the maintainers would prefer.

Best,
Sean