### PR TITLE
link to installation instructions page in workshop template

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -107,7 +107,7 @@ you can run it by opening a terminal and typing `bash`.
 ::::::::::::
 
 [zip-file]: data/shell-lesson-data.zip
-[install_shell]: https://carpentries.github.io/workshop-template/#shell
+[install_shell]: https://carpentries.github.io/workshop-template/install_instructions/#shell
 [wsl]: https://learn.microsoft.com/en-us/windows/wsl/install
 [mac-terminal]: https://www.macworld.co.uk/feature/mac-software/how-use-terminal-on-mac-3608274/
 [gnome-terminal]: https://help.gnome.org/users/gnome-terminal/stable/


### PR DESCRIPTION
To reduce confusion for learners visiting the installation instructions, this links to a dedicated page of installation instructions in the template workshop website. This is instead of the template landing page, which contains a lot of FIXMEs that can be alarming and give someone the impression that the link has taken them to the wrong place.

See #1417 for additional context.