### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ If you would like to contribute to the development of the lesson, you can find d
 Contributions can come in many different forms: typo and formatting fixes, additions or subtractions
 of content, suggestions, clarifications, and more.
 
-[slack_invite]: https://swc-slack-invite.herokuapp.com/
+[slack_invite]: https://slack-invite.carpentries.org/
 [create_slack_svg]: https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg
-[slack_status]: https://swcarpentry.slack.com/messages/C9X3XTHJ8
+[slack_status]: https://carpentries.slack.com/messages/C9X3XTHJ8
 [slack_status_svg]: https://img.shields.io/badge/Slack_Channel-swc--shell-E01563.svg
 [doi]: https://doi.org/10.5281/zenodo.3266823
 [doi_svg]: https://zenodo.org/badge/DOI/10.5281/zenodo.3266823.svg


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.
