### PR TITLE
Formulate more clearly

### DIFF
--- a/episodes/05-loop.md
+++ b/episodes/05-loop.md
@@ -104,8 +104,7 @@ In this example, the list is three filenames: `basilisk.dat`, `minotaur.dat`, an
 Each time the loop iterates, we first use `echo` to print the value that the variable
 `$filename` currently holds. This is not necessary for the result, but beneficial for us here to
 have an easier time to follow along.
-Next, we will assign a file name to the variable `filename`
-and run the `head` command.
+Next, we will run the `head` command on the file currently referred to by $filename.
 The first time through the loop,
 `$filename` is `basilisk.dat`.
 The interpreter runs the command `head` on `basilisk.dat`


### PR DESCRIPTION
A sentence was formulated more precisely.

The formulation "Next, we will assign a file name to the variable filename..." is misleading for two reasons:

1. The assignment to $filename happens before the first step inside the loop.
2. The assignment is not done by us, the users, but by the shell interpreter.
