### PR TITLE
Adding missing spaces between words

### DIFF
--- a/02-filedir.html
+++ b/02-filedir.html
@@ -614,7 +614,7 @@ lesson.</p>
 <i class="callout-icon" data-feather="zap"></i>
 </div>
 <div id="exploring-more-ls-options" class="callout-inner">
-<h3 class="callout-title">Exploring More<code>ls</code>Options<a class="anchor" aria-label="anchor" href="#exploring-more-ls-options"></a>
+<h3 class="callout-title">Exploring More <code>ls</code> Options<a class="anchor" aria-label="anchor" href="#exploring-more-ls-options"></a>
 </h3>
 <div class="callout-content">
 <p>You can also use two options at the same time. What does the command
@@ -1074,7 +1074,7 @@ display?</p>
 </div>
 <div id="ls-reading-comprehension" class="callout-inner">
 <h3 class="callout-title">
-<code>ls</code>Reading Comprehension<a class="anchor" aria-label="anchor" href="#ls-reading-comprehension"></a>
+<code>ls</code> Reading Comprehension<a class="anchor" aria-label="anchor" href="#ls-reading-comprehension"></a>
 </h3>
 <div class="callout-content">
 <p>Using the filesystem diagram below, if <code>pwd</code> displays


### PR DESCRIPTION
Small correction in .html: in some subheadings the words are stuck together.

Before:
![Screenshot from 2024-01-03 19-30-19](https://github.com/swcarpentry/shell-novice/assets/30404270/3e3c597b-5379-455f-8879-82a65347ce09)

After:
![Screenshot from 2024-01-03 19-32-09](https://github.com/swcarpentry/shell-novice/assets/30404270/20ea7931-21ce-4c4d-8127-08b007f547ff)

This is my very first pull request so I'm sorry if I did something wrong.