### PR TITLE
Fix spelling mistake in 04-pipefilter.md

### DIFF
--- a/episodes/04-pipefilter.md
+++ b/episodes/04-pipefilter.md
@@ -550,7 +550,7 @@ $ cut -d , -f 2 animals.csv
 
 The `cut` command is used to remove or 'cut out' certain sections of each line in the file,
 and `cut` expects the lines to be separated into columns by a <kbd>Tab</kbd> character.
-A character used in this way is a called a **delimiter**.
+A character used in this way is called a **delimiter**.
 In the example above we use the `-d` option to specify the comma as our delimiter character.
 We have also used the `-f` option to specify that we want to extract the second field (column).
 This gives the following output:


### PR DESCRIPTION
While going through the awesome tutorials I noticed a small mistake:

From "A character used in this way is a called a delimiter" to "A character used in this way is called a delimiter."

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
