### PR TITLE
Use `q` instead of `Q` to quit the man pages in 02-filedir.md

### DIFF
--- a/episodes/02-filedir.md
+++ b/episodes/02-filedir.md
@@ -311,7 +311,7 @@ Sometimes a search will result in multiple hits.
 If so, you can move between hits using <kbd>N</kbd> (for moving forward) and
 <kbd>Shift</kbd>\+<kbd>N</kbd> (for moving backward).
 
-To **quit** the `man` pages, press <kbd>Q</kbd>.
+To **quit** the `man` pages, press <kbd>q</kbd>.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 


### PR DESCRIPTION
Use `q` instead of `Q` to quit the man pages in `02-filedir.md`