### PR TITLE
Fix typo in 03-create.md

### DIFF
--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -755,7 +755,7 @@ list of matching filenames *before* running the preceding command.
 As an exception, if a wildcard expression does not match
 any file, Bash will pass the expression as an argument to the command
 as it is. For example, typing `ls *.pdf` in the `alkanes` directory
-(which contains only files with names ending with `.pdb`) results in
+(which contains only files with names ending with `.pdf`) results in
 an error message that there is no file called `*.pdf`.
 However, generally commands like `wc` and `ls` see the lists of
 file names matching these expressions, but not the wildcards


### PR DESCRIPTION


_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

Fixed a typo. "*.pdf" is wrongly said to be all files ending with ".pdb" instead of ".pdf"

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
