### PR TITLE
Add explanation for grep -o option

### DIFF
--- a/episodes/07-find.md
+++ b/episodes/07-find.md
@@ -397,6 +397,8 @@ do
 done
 ```
 
+The `-o` option for `grep` (short for --only-matching) prints each matched part of the line on a separate output line. This is useful when you want to count the total number of occurrences of a pattern, rather than the number of lines containing the pattern. By piping the output of `grep -o` to `wc -l` (word count - lines), we can count each occurrence individually.
+
 Alternative, slightly inferior solution:
 
 ```source


### PR DESCRIPTION
The "Little Women" exercise in the finding things episode (07-find.md) used grep -o without explaining what it does or why it was used.


_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

closes #1489 


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This commit adds a hint to the exercise solution, clarifying that `grep -o` prints each match on a new line, and explaining that this is why it's used with `wc -l` to count all occurrences of a pattern.


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
