### PR TITLE
moved shell extra lesson reference

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,11 +21,6 @@ shell. If you have stored files on a computer at all and recognize
 the word "file" and either "directory" or "folder" (two common words
 for the same thing), you're ready for this lesson.
 
-If you're already comfortable manipulating files and directories,
-searching for files with `grep` and `find`, and writing simple loops
-and scripts, you probably want to explore the next lesson:
-[shell-extras](https://carpentries-incubator.github.io/shell-extras/).
-
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/learners/resources.md
+++ b/learners/resources.md
@@ -1,0 +1,10 @@
+---
+title: Additional Resources
+---
+
+
+
+To learn more about the Unix shell you may want to explore the 
+[shell-extras](https://carpentries-incubator.github.io/shell-extras/) lesson in the Carpentries Incubator.
+
+


### PR DESCRIPTION
fixes #1455

- Removed the reference to shell extra lesson in the prereqs
- Created Additional Resources page for learners and added text about shell extra lesson

Might recommend we open a new issue looking for additional resources in include on that page, it is a little sparse at present.