### PR TITLE
Fixing a Typo in "Finding Things" episode

### DIFF
--- a/episodes/07-find.md
+++ b/episodes/07-find.md
@@ -33,7 +33,7 @@ we will use a file that contains three haiku taken from a
 [1998 competition](https://web.archive.org/web/19991201042211/http://salon.com/21st/chal/1998/01/26chal.html)
 in *Salon* magazine (Credit to authors Bill Torcaso, Howard Korder, and
 Margaret Segall, respectively. See
-Haiku Error Messsages archived
+Haiku Error Messages archived
 [Page 1](https://web.archive.org/web/20000310061355/http://www.salon.com/21st/chal/1998/02/10chal2.html)
 and
 [Page 2](https://web.archive.org/web/20000229135138/http://www.salon.com/21st/chal/1998/02/10chal3.html)


### PR DESCRIPTION
Typo: Removed an extra s in messages from "Haiku Error Messsages archived".

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
