### PR TITLE
Simplifies second example of loops

### DIFF
--- a/episodes/05-loop.md
+++ b/episodes/05-loop.md
@@ -415,7 +415,7 @@ Given the output from the `cat` command has been redirected, nothing is printed 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Let's continue with our example in the `shell-lesson-data/exercise-data/creatures` directory.
-Here's a slightly more complicated loop:
+Here's another example:
 
 ```bash
 $ for filename in *.dat
@@ -428,37 +428,9 @@ $ for filename in *.dat
 The shell starts by expanding `*.dat` to create the list of files it will process.
 The **loop body**
 then executes two commands for each of those files.
-The first command, `echo`, prints its command-line arguments to standard output.
-For example:
-
-```bash
-$ echo hello there
-```
-
-prints:
-
-```output
-hello there
-```
-
-In this case,
-since the shell expands `$filename` to be the name of a file,
-`echo $filename` prints the name of the file.
-Note that we can't write this as:
-
-```bash
-$ for filename in *.dat
-> do
->     $filename
->     head -n 100 $filename | tail -n 20
-> done
-```
-
-because then the first time through the loop,
-when `$filename` expanded to `basilisk.dat`, the shell would try to run `basilisk.dat` as
-a program.
-Finally,
-the `head` and `tail` combination selects lines 81-100
+In the first command, `$filename` is expanded to the name of the file,
+so `echo $filename` prints the name of the file.
+Then, the `head` and `tail` combination selects lines 81-100
 from whatever file is being processed
 (assuming the file has at least 100 lines).
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Closes #1444


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
This PR simplifies the second example of loops, removing the phrasing that it is "more complicated" (because it isn't particularly more complicated), removes the explanation of the `echo` command (which had already been explained) as well as the note that you can't just type `$filename` instead of `echo $filename` (I don't see any good reason why a learner would be under the impression that this would work?)


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
