### PR TITLE
Fix goostats.sh shell script

### DIFF
--- a/shell-lesson-data/north-pacific-gyre/goostats.sh
+++ b/shell-lesson-data/north-pacific-gyre/goostats.sh
@@ -11,11 +11,11 @@ then
 fi
 
 # check if files already exist (good for $1, bad for $2)
-if [ ! -a "$1" ]
+if [ ! -f "$1" ]
 then
     echo "error reading input: $1"
     exit 2
-elif [ -a "$2" ]
+elif [ -e "$2" ]
 then
     echo "error writing result: $2"
     exit 2


### PR DESCRIPTION
In the lesson "Nelle's Pipeline: Processing Files" the shell script goostats.sh does not work. It produces an 'error reading input' error. The issue is linesq 14 and 18.

Line 14 changed from:
if [ ! -a "$1" ]

to:
if [ ! -f "$1" ]

Line 18 changed from:
if [ ! -a "$2" ]

to:
elif [ -e "$2" ]

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
