### PR TITLE
provide link to "Options" in glossary

### DIFF
--- a/episodes/02-filedir.md
+++ b/episodes/02-filedir.md
@@ -916,7 +916,7 @@ and we will see it in many other tools as we go on.
 
 
 [Arguments]: https://swcarpentry.github.io/shell-novice/reference.html#argument
-
+[Options]: https://swcarpentry.github.io/shell-novice/reference.html#option
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
The glossary reference in line 800 is not rendered because the link is missing.