### PR TITLE
Remove note about nano and the SWC Windows Installer

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -203,13 +203,6 @@ as long as learners using Windows do not run into roadblocks such as:
   PS1='$ '
   ```
 
-- On Windows machines
-  if `nano` hasn't been properly installed with the
-  [Software Carpentry Windows Installer][windows-installer]
-  it is possible to use `notepad` as an alternative.  There will be a GUI
-  interface and line endings are treated differently, but otherwise, for
-  the purposes of this lesson, `notepad` and `nano` can be used almost interchangeably.
-
 - On Windows, it appears that:
   
   ```bash


### PR DESCRIPTION
The Instructor Notes refer to the Software Carpentry Windows Installer, and a potential issue with `nano` when using it. We have not used the Installer for a long time and have received no reports of `nano` being unavailable on Windows systems after following the setup instructions. This PR removes that item from the Instructor Notes. 