### PR TITLE
Remove broken link (#1532)

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -109,7 +109,7 @@ you can run it by opening a terminal and typing `bash`.
 [zip-file]: data/shell-lesson-data.zip
 [install_shell]: https://carpentries.github.io/workshop-template/install_instructions/#shell
 [wsl]: https://learn.microsoft.com/en-us/windows/wsl/install
-[mac-terminal]: https://www.macworld.co.uk/feature/mac-software/how-use-terminal-on-mac-3608274/
+[mac-terminal]: https://support.apple.com/en-ke/guide/terminal/welcome/mac
 [gnome-terminal]: https://help.gnome.org/users/gnome-terminal/stable/
 [kde-konsole]: https://konsole.kde.org/
 [xterm]: https://en.wikipedia.org/wiki/Xterm


### PR DESCRIPTION
- Backport: replacement URL from a0dd061b706858c02bac0e2cc668897e683ff5e3

Closes #1532 

The previous commit a0dd061b706858c02bac0e2cc668897e683ff5e3 fixed the URL in the references, but not the setup page.