### PR TITLE
Update error handling in goostats.sh

### DIFF
--- a/shell-lesson-data/north-pacific-gyre/goostats.sh
+++ b/shell-lesson-data/north-pacific-gyre/goostats.sh
@@ -5,19 +5,19 @@
 # check for the right number of input arguments
 if [ $# -ne 2 ]
 then
-    echo "call goostats with two arguments:"
-    echo "  $0 input_file result_file"
+    echo "call goostats with two arguments:" >&2
+    echo "  $0 input_file result_file" >&2
     exit 1
 fi
 
 # check if files already exist (good for $1, bad for $2)
 if [ ! -e "$1" ]
 then
-    echo "error reading input: $1"
+    echo "error reading input: $1" >&2
     exit 2
 elif [ -e "$2" ]
 then
-    echo "error writing result: $2"
+    echo "error writing result: $2" >&2
     exit 2
 fi
 

--- a/shell-lesson-data/north-pacific-gyre/goostats.sh
+++ b/shell-lesson-data/north-pacific-gyre/goostats.sh
@@ -13,11 +13,11 @@ fi
 # check if files already exist (good for $1, bad for $2)
 if [ ! -e "$1" ]
 then
-    echo "error reading input: $1" >&2
+    echo "error reading input: file $1 does not exist" >&2
     exit 2
 elif [ -e "$2" ]
 then
-    echo "error writing result: $2" >&2
+    echo "error writing result: file $2 already exists" >&2
     exit 2
 fi
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Closes #1555

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
I've made two changes:
1. I've added details to the error messages when reading/writing files fails so that learners know why the script failed to run.
2. I have directed `echo` commands to print to `stderr`. This ensures that the errors printed out if one runs both forms of the `bash do-stats.sh` commands in https://github.com/swcarpentry/shell-novice/blob/7f71c428647cbb4251bd0f2ac9837a42a10c35f8/episodes/06-script.md#nelles-pipeline-creating-a-script that the `wc -l` will still just print the number of files processed as the episode text describes.

I'm hoping to reduce confusion for learners when they run goostats.sh with invalid filename arguments.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
